### PR TITLE
Add Netlify redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+[[redirects]]
+  from = "/old-path"
+  to = "/new-path"
+  status = 301
+  force = false
+  query = {path = ":path"} # apply this rule for /old-path?path=example
+  conditions = {Language = ["en","es"], Country = ["US"]}
+
+[[redirects]]
+  from = "/news"
+  to = "/blog"
+  status = 301


### PR DESCRIPTION
## Summary
- add Netlify redirect rules for /old-path and /news
- document query parameter behavior and explicitly set 301 status

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c52cd10a14832e87f6f46aa35f17ee