### PR TITLE
Add Netlify redirects and placeholder build script

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+[[redirects]]
+  from = "/old-path"
+  to = "/new-path"
+  status = 301
+  force = false
+  query = {path = ":path"} # apply this rule for /old-path?path=example
+  conditions = {Language = ["en","es"], Country = ["US"]}
+
+[[redirects]]
+  from = "/news"
+  to = "/blog"
+  status = 301

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "chatgpt-project",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "echo 'no build step defined'",
+    "test": "echo 'no tests specified'"
+  }
+}


### PR DESCRIPTION
## Summary
- add Netlify redirect rules for /old-path and /news
- provide minimal package.json so Netlify build/test commands succeed

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c52cd10a14832e87f6f46aa35f17ee