### PR TITLE
chore: pin netlify to node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ npm install
 ## Netlify
 Pushes to `main` or `File-Viewer-App` deploy via GitHub Actions.
 Set `NETLIFY_AUTH_TOKEN` in repository secrets for deployment.
+The build environment is pinned to Node.js 20 in `netlify.toml`.
 
 ## Contributing
 1. Fork and clone the repo.

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   publish = "dist"
   command = "npm run build"
 
+  [build.environment]
+    NODE_VERSION = "20"
+
 [[headers]]
   for = "/app.html"
   [headers.values]


### PR DESCRIPTION
## Summary
- configure Netlify builds to use Node.js 20
- note Netlify's Node.js version in documentation

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c572857808832e922b1f60a14d1247