### PR TITLE
Restrict permissions for Netlify deployment workflow

### DIFF
--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -2,6 +2,8 @@ name: netlify-deploy
 on:
   push:
     branches: [ main, File-Viewer-App ]
+permissions:
+  contents: read
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- limit `GITHUB_TOKEN` scope for Netlify deploy workflow to `contents: read`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5775b922c832ead877b2cc93f697d