### PR TITLE
chore: limit workflow permissions

### DIFF
--- a/.github/workflows/build-and-check.yml
+++ b/.github/workflows/build-and-check.yml
@@ -4,9 +4,14 @@ on:
     branches: [ main, File-Viewer-App ]
   pull_request:
     branches: [ main ]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- restrict default token to read-only access
- grant artifact upload job the minimal write scope

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5775990a0832e961e54c507b00f02