### PR TITLE
Add North Star ReleaseDeck component and static dist; fix build packaging for Netlify

### DIFF
--- a/apps/storyboard/dist/ReleasePlanDeck.jsx
+++ b/apps/storyboard/dist/ReleasePlanDeck.jsx
@@ -1,0 +1,898 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Upload,
+  Target,
+  Snowflake,
+  Sparkles,
+  Radio,
+  CheckCircle2,
+  Gauge,
+  Link2,
+  Layers,
+  FileDown,
+} from "lucide-react";
+
+/**
+ * FIX: Miljön kastar fel på färgfunktionen `oklch`.
+ * Orsak: vissa Tailwind-färgtokens (t.ex. zinc-*) kan kompilera till `oklch(...)` i den här runtime:n.
+ * Lösning: vi använder INGA Tailwind color utilities alls (ingen text-zinc-*, bg-zinc-*, border-zinc-* osv)
+ * och sätter färger via inline styles (hex/rgba) som funkar överallt.
+ *
+ * PDF-export finns kvar (html2canvas + jsPDF), och får en “säljande deck”-layout.
+ */
+
+const THEME = {
+  bg: "#050507",
+  panel: "rgba(15, 15, 18, 0.55)",
+  panel2: "rgba(10, 10, 12, 0.55)",
+  border: "rgba(255, 255, 255, 0.10)",
+  border2: "rgba(255, 255, 255, 0.14)",
+  text: "#F4F4F5",
+  text2: "#D4D4D8",
+  text3: "#A1A1AA",
+  text4: "#71717A",
+  shadow: "0 20px 70px -30px rgba(0,0,0,0.85)",
+};
+
+const cx = (...a) => a.filter(Boolean).join(" ");
+
+const Surface = ({ children, style, className }) => (
+  <div
+    className={className}
+    style={{
+      background: THEME.bg,
+      color: THEME.text,
+      ...style,
+    }}
+  >
+    {children}
+  </div>
+);
+
+const SlideShell = ({ children }) => (
+  <Surface>
+    <div className="min-h-screen w-full">
+      <div className="mx-auto max-w-6xl px-6 py-10 md:py-14">{children}</div>
+    </div>
+  </Surface>
+);
+
+const Card = ({ className, children, style }) => (
+  <div
+    className={cx("rounded-2xl border", className)}
+    style={{
+      borderColor: THEME.border,
+      background: THEME.panel,
+      boxShadow: THEME.shadow,
+      ...style,
+    }}
+  >
+    {children}
+  </div>
+);
+
+const Pill = ({ icon: Icon, title, children }) => (
+  <div className="flex items-start gap-3">
+    <div
+      className="mt-0.5 rounded-xl border p-2"
+      style={{ borderColor: THEME.border, background: THEME.panel2 }}
+    >
+      <Icon className="h-5 w-5" style={{ color: THEME.text2 }} />
+    </div>
+    <div>
+      <div className="text-sm font-semibold tracking-wide" style={{ color: THEME.text2 }}>
+        {title}
+      </div>
+      <div className="mt-1 text-sm leading-relaxed" style={{ color: THEME.text3 }}>
+        {children}
+      </div>
+    </div>
+  </div>
+);
+
+const SectionTitle = ({ kicker, title, subtitle }) => (
+  <div>
+    {kicker ? (
+      <div
+        className="mb-2 inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs tracking-[0.2em]"
+        style={{ borderColor: THEME.border, background: THEME.panel2, color: THEME.text3 }}
+      >
+        <Radio className="h-3.5 w-3.5" style={{ color: THEME.text3 }} />
+        {kicker}
+      </div>
+    ) : null}
+
+    <div className="text-3xl md:text-4xl font-semibold tracking-tight" style={{ color: THEME.text }}>
+      {title}
+    </div>
+
+    {subtitle ? (
+      <div
+        className="mt-3 max-w-3xl text-base md:text-lg leading-relaxed"
+        style={{ color: THEME.text3 }}
+      >
+        {subtitle}
+      </div>
+    ) : null}
+  </div>
+);
+
+const TimelineRow = ({ week, purpose, items, microcopy }) => (
+  <Card className="p-5 md:p-6">
+    <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+      <div className="min-w-[190px]">
+        <div className="text-xs tracking-[0.2em]" style={{ color: THEME.text4 }}>
+          {week}
+        </div>
+        <div className="mt-1 text-lg font-semibold" style={{ color: THEME.text }}>
+          {purpose}
+        </div>
+      </div>
+      <div className="flex-1">
+        <ul className="space-y-2 text-sm leading-relaxed" style={{ color: THEME.text3 }}>
+          {items.map((x, i) => (
+            <li key={i} className="flex gap-2">
+              <span
+                className="mt-1 h-1.5 w-1.5 rounded-full"
+                style={{ background: "rgba(255,255,255,0.28)" }}
+              />
+              <span>{x}</span>
+            </li>
+          ))}
+        </ul>
+
+        {microcopy ? (
+          <div
+            className="mt-4 rounded-xl border px-4 py-3 text-sm"
+            style={{ borderColor: THEME.border, background: THEME.panel2, color: THEME.text2 }}
+          >
+            <span style={{ color: THEME.text4 }}>Exempeltext: </span>
+            <span className="font-semibold tracking-wide">{microcopy}</span>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  </Card>
+);
+
+const Checklist = ({ items }) => (
+  <div className="grid gap-3">
+    {items.map((x, i) => (
+      <div
+        key={i}
+        className="flex items-start gap-3 rounded-2xl border p-4"
+        style={{ borderColor: THEME.border, background: THEME.panel2 }}
+      >
+        <CheckCircle2 className="mt-0.5 h-5 w-5" style={{ color: THEME.text2 }} />
+        <div className="text-sm leading-relaxed" style={{ color: THEME.text3 }}>
+          {x}
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+function useLocalImage() {
+  const [dataUrl, setDataUrl] = useState(null);
+  const [fileName, setFileName] = useState(null);
+
+  const onPick = async (file) => {
+    if (!file) return;
+    const ok = /image\/(png|jpeg|jpg|webp)/.test(file.type);
+    if (!ok) {
+      alert("Välj en PNG/JPG/WebP.");
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      setDataUrl(reader.result);
+      setFileName(file.name);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return {
+    dataUrl,
+    fileName,
+    onPick,
+    clear: () => (setDataUrl(null), setFileName(null)),
+  };
+}
+
+function SlideBody({ slide, img }) {
+  return (
+    <div
+      className="rounded-3xl border p-6 md:p-10"
+      style={{
+        borderColor: THEME.border,
+        backgroundImage:
+          "linear-gradient(180deg, rgba(255,255,255,0.04) 0%, rgba(255,255,255,0.015) 100%)",
+        backgroundColor: "rgba(0,0,0,0)",
+      }}
+    >
+      <SectionTitle kicker={slide.kicker} title={slide.title} subtitle={slide.subtitle} />
+      {slide.body(img)}
+    </div>
+  );
+}
+
+async function loadPdfDeps() {
+  const [{ default: html2canvas }, { jsPDF }] = await Promise.all([
+    import("html2canvas"),
+    import("jspdf"),
+  ]);
+  return { html2canvas, jsPDF };
+}
+
+// --- TESTS ---
+// Enkla runtime-testfall: säkerställ att vi inte använder oklch-känsliga Tailwind color utilities.
+function runSelfTests() {
+  const forbidden = [
+    "text-zinc-",
+    "bg-zinc-",
+    "border-zinc-",
+    "from-zinc-",
+    "to-zinc-",
+    "via-zinc-",
+    "text-neutral-",
+    "bg-neutral-",
+    "border-neutral-",
+  ];
+
+  const haystack = JSON.stringify({});
+  // Notera: vi kan inte enkelt inspektera JSX här, men vi kan testa att THEME har hex/rgba och inte oklch.
+  const themeStr = JSON.stringify(THEME);
+
+  console.assert(!/oklch\(/i.test(themeStr), "THEME innehåller oklch — ska inte hända.");
+  console.assert(/^#/.test(THEME.bg), "THEME.bg ska vara hex.");
+  console.assert(/rgba\(/.test(THEME.panel), "THEME.panel ska vara rgba.");
+
+  // Dummy test för att hålla listan vid liv (för framtida refactors).
+  console.assert(Array.isArray(forbidden) && forbidden.length > 0, "Forbidden tokens ska finnas.");
+  console.assert(typeof haystack === "string", "Sanity check.");
+}
+
+export default function ReleasePlanDeck() {
+  const [idx, setIdx] = useState(0);
+  const [busy, setBusy] = useState(false);
+  const img = useLocalImage();
+  const hiddenRefs = useRef([]);
+
+  useEffect(() => {
+    runSelfTests();
+  }, []);
+
+  const slides = useMemo(
+    () => [
+      {
+        id: "hero",
+        title: "North Star Rising — Releaseplan & Social Media-plan",
+        kicker: "KALL SIGNAL / KALL PRECISION",
+        subtitle:
+          "En körbar deck som styr tonalitet, tempo och publicerings-tryck. Ingen förklaring. Bara signal.",
+        body: (img) => (
+          <div className="grid gap-6 md:grid-cols-12 mt-8">
+            <div className="md:col-span-7">
+              <Card className="p-6 md:p-7">
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <div className="text-xs tracking-[0.2em]" style={{ color: THEME.text4 }}>
+                      NYCKELASSET
+                    </div>
+                    <div className="mt-1 text-lg font-semibold" style={{ color: THEME.text }}>
+                      Bifogad 3x3-panel
+                    </div>
+                    <div className="mt-1 text-sm" style={{ color: THEME.text3 }}>
+                      Ladda upp bilden så blir den ett centralt element i hela presentationen.
+                    </div>
+                  </div>
+
+                  <label
+                    className="cursor-pointer inline-flex items-center gap-2 rounded-2xl border px-4 py-3 text-sm"
+                    style={{ borderColor: THEME.border, background: THEME.panel2, color: THEME.text2 }}
+                  >
+                    <Upload className="h-4 w-4" style={{ color: THEME.text2 }} />
+                    <span>Ladda upp bild</span>
+                    <input
+                      type="file"
+                      accept="image/*"
+                      className="hidden"
+                      onChange={(e) => img.onPick(e.target.files?.[0])}
+                    />
+                  </label>
+                </div>
+
+                <div className="mt-5 grid gap-4 md:grid-cols-2">
+                  <Pill icon={Target} title="Mål (hårt)">
+                    Igenkänning + mystik. Förväntan. Max tryck första 48 timmar.
+                  </Pill>
+                  <Pill icon={Snowflake} title="Estetik (helig)">
+                    Svart/vitt, stål, is, rök, ljuskontrast, symbolik. Minimal accent.
+                  </Pill>
+                  <Pill icon={Gauge} title="Tempo">
+                    Långsamt → explosivt. Tease bygger spänning. Release smäller.
+                  </Pill>
+                  <Pill icon={Radio} title="Persona">
+                    Anonym styrka. Kall precision. Nordisk tyngd. Inga emojis. Inga ursäkter.
+                  </Pill>
+                </div>
+
+                <div
+                  className="mt-5 rounded-2xl border p-4"
+                  style={{ borderColor: THEME.border, background: THEME.panel2 }}
+                >
+                  <div className="text-xs tracking-[0.2em]" style={{ color: THEME.text4 }}>
+                    MINDSET
+                  </div>
+                  <div className="mt-2 text-base md:text-lg font-semibold tracking-tight" style={{ color: THEME.text }}>
+                    “Vi förklarar inte — vi visar.”
+                  </div>
+                </div>
+              </Card>
+            </div>
+
+            <div className="md:col-span-5">
+              <Card className="p-3">
+                <div
+                  className="aspect-square w-full overflow-hidden rounded-xl border"
+                  style={{ borderColor: THEME.border, background: THEME.panel2 }}
+                >
+                  {img.dataUrl ? (
+                    <img
+                      src={img.dataUrl}
+                      alt={img.fileName || "Key visual"}
+                      className="h-full w-full object-cover"
+                      crossOrigin="anonymous"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center p-8 text-center">
+                      <div>
+                        <div className="text-sm" style={{ color: THEME.text3 }}>
+                          Ingen bild laddad ännu.
+                        </div>
+                        <div className="mt-2 text-xs" style={{ color: THEME.text4 }}>
+                          Klicka “Ladda upp bild” och välj den bifogade 3x3-panelen.
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+                <div className="mt-3 px-2 pb-2 text-xs" style={{ color: THEME.text4 }}>
+                  Tips: Kör samma bild som grid-post, men även som beskärda utsnitt i reels/stories.
+                </div>
+              </Card>
+            </div>
+          </div>
+        ),
+      },
+
+      {
+        id: "rules",
+        kicker: "REGLER SOM INTE FÅR BRYTAS",
+        title: "Estetik, text och disciplin",
+        subtitle:
+          "Det här är ert “style police”-slide. Om ett inlägg inte följer detta: kasta det. Hellre få stenhårda posts än mycket brus.",
+        body: () => (
+          <div className="mt-8 grid gap-6 md:grid-cols-12">
+            <div className="md:col-span-7">
+              <Card className="p-6 md:p-7">
+                <div className="grid gap-4">
+                  <Pill icon={Snowflake} title="Visuellt språk">
+                    Nära monokrom bas (kallt stål/aska/is). Rök/volumetrics. Hård ljuskontrast. Symbolen är diegetisk.
+                  </Pill>
+                  <Pill icon={Sparkles} title="Textspråk">
+                    Kort. Suggestivt. Imperativt. Punkt. Inga emojis. Inga förklaringar. Aldrig “nu släpper vi…”-snack.
+                  </Pill>
+                  <Pill icon={Gauge} title="Tempo & dramaturgi">
+                    Vecka -3/-2: bygg signal. Vecka -1: namnge. Releasedag: överkör.
+                  </Pill>
+                  <Pill icon={Layers} title="Upprepning (med flit)">
+                    Samma visuella språk tills det sätter sig. Variation = utsnitt, timing, ljudbit — inte ny identitet.
+                  </Pill>
+                </div>
+              </Card>
+            </div>
+            <div className="md:col-span-5">
+              <Card className="p-6">
+                <div className="text-xs tracking-[0.2em]" style={{ color: THEME.text4 }}>
+                  COPY BANK (KORT & KALL)
+                </div>
+                <div className="mt-4 space-y-3 text-sm" style={{ color: THEME.text2 }}>
+                  {[
+                    "THE SIGNAL IS LIVE.",
+                    "COLD PROTOCOL ACTIVE",
+                    "TRANSMISSION RECEIVED",
+                    "NO HEAT. NO MERCY.",
+                    "YOU HEARD IT. NOW MOVE.",
+                    "REPEAT.",
+                    "SECOND WAVE",
+                  ].map((t, i) => (
+                    <div
+                      key={i}
+                      className="rounded-xl border px-4 py-3 font-semibold tracking-wide"
+                      style={{ borderColor: THEME.border, background: THEME.panel2 }}
+                    >
+                      {t}
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-4 text-xs" style={{ color: THEME.text4 }}>
+                  Stark åsikt: ni vinner på militär minimalism. Folk blir trygga av att ni *låter* som en maskin.
+                </div>
+              </Card>
+            </div>
+          </div>
+        ),
+      },
+
+      {
+        id: "timeline",
+        kicker: "3 VECKOR RUNT RELEASEN",
+        title: "Tidslinje som går att följa utan att tappa kyla",
+        subtitle:
+          "Strukturen nedan är designad för igenkänning, frekvensdisciplin och maximal conversion på dag 0–2.",
+        body: () => (
+          <div className="mt-8 grid gap-4">
+            <TimelineRow
+              week="VECKA −3"
+              purpose="Tease / Närvaro"
+              items={[
+                "2–3 inlägg: stillbild eller 5–7s mörk loop (rök/rörelse/ljus)",
+                "Story: nedräkning utan kontext (bara datum/symbol)",
+                "CTA: ingen — du vill ha nyfikenhet, inte friktion",
+              ]}
+              microcopy="NORTHSTAR RISING — INITIATED"
+            />
+            <TimelineRow
+              week="VECKA −2"
+              purpose="Identitet"
+              items={[
+                "3–4 inlägg: reveal av logotyp/emblem (kallt, rent)",
+                "8–10s reel med instrumental snippet (utan titel)",
+                "Stillbild från artwork (delbeskuren) för att tvinga folk att “fylla i”",
+                "Story: poll “Cold / Colder” + loopad ljudsnutt",
+              ]}
+              microcopy="A NEW SIGNAL EMERGES — NORTHSTAR RISING"
+            />
+            <TimelineRow
+              week="VECKA −1"
+              purpose="Singelannonsering"
+              items={[
+                "4–5 inlägg: artwork reveal (hel bild)",
+                "Titel + releasedatum (en rad)",
+                "10–12s reel med refräng-drop",
+                "Pre-save post (link in bio) — inga ursäkter, bara order",
+                "Story: daglig nedräkning + hook-loop + pre-save",
+              ]}
+              microcopy="FROZEN IN CARBIDE — OUT [DATUM]"
+            />
+            <TimelineRow
+              week="RELEASEDAG"
+              purpose="Max tryck (48h)"
+              items={[
+                "Reel/video med starkaste delen (det ska kännas oundvikligt)",
+                "Stillbild + tydlig länk",
+                "Story x3: OUT NOW → Swipe/Link → Repost första reaktioner",
+                "Pinned post: singelreel",
+              ]}
+              microcopy="OUT NOW"
+            />
+            <TimelineRow
+              week="VECKA +1"
+              purpose="Eftertryck"
+              items={[
+                "3–4 inlägg: lyric-video loop + visualizer-clip",
+                "“Behind the sound” (abstrakt — inga pratiga selfies)",
+                "Kommentar-screenshot från lyssnare",
+              ]}
+              microcopy="YOU HEARD THE SIGNAL. NOW SPREAD IT."
+            />
+          </div>
+        ),
+      },
+
+      {
+        id: "platform",
+        kicker: "PLATTFORMAR",
+        title: "Samma signal — olika förpackning",
+        subtitle:
+          "Ni är inte här för att ‘vara sociala’. Ni är här för att skicka en kall signal, om och om igen, tills folk lyssnar.",
+        body: () => (
+          <div className="mt-8 grid gap-6 md:grid-cols-12">
+            <div className="md:col-span-7">
+              <Card className="p-6 md:p-7">
+                <div className="grid gap-4">
+                  <Pill icon={Radio} title="Instagram (huvudplattform)">
+                    Reels + Stories. Pinna singelreelen. Stories = nedräkning, poll, reaktioner.
+                  </Pill>
+                  <Pill icon={Radio} title="Facebook">
+                    Samma content men lägre frekvens. Hellre kvalitet än “närvaro”.
+                  </Pill>
+                  <Pill icon={Radio} title="TikTok (om ni kör)">
+                    7–10s drops. Loop-vänliga breakdowns. Inga förklaringar. Bara kraft.
+                  </Pill>
+                  <Pill icon={Link2} title="CTA-hygien">
+                    Vecka -3/-2: ingen CTA. Vecka -1: pre-save. Releasedag: OUT NOW + länk. Klart.
+                  </Pill>
+                </div>
+              </Card>
+            </div>
+            <div className="md:col-span-5">
+              <Card className="p-6">
+                <div className="text-xs tracking-[0.2em]" style={{ color: THEME.text4 }}>
+                  FORMAT-MALLAR
+                </div>
+                <div className="mt-4 space-y-3 text-sm" style={{ color: THEME.text3 }}>
+                  <div className="rounded-xl border p-4" style={{ borderColor: THEME.border, background: THEME.panel2 }}>
+                    <div className="font-semibold" style={{ color: THEME.text2 }}>
+                      Reel 8–12s
+                    </div>
+                    <div className="mt-1">
+                      0.0–1.0s: visuellt “hook”. 1–10s: musikdrop. 10–12s: logga + 1 rad text.
+                    </div>
+                  </div>
+                  <div className="rounded-xl border p-4" style={{ borderColor: THEME.border, background: THEME.panel2 }}>
+                    <div className="font-semibold" style={{ color: THEME.text2 }}>
+                      Story (3-pack)
+                    </div>
+                    <div className="mt-1">1) signal/visual. 2) datum/OUT NOW. 3) länk/repost reaktion.</div>
+                  </div>
+                  <div className="rounded-xl border p-4" style={{ borderColor: THEME.border, background: THEME.panel2 }}>
+                    <div className="font-semibold" style={{ color: THEME.text2 }}>
+                      Stillbild
+                    </div>
+                    <div className="mt-1">Hel bild (vecka -1 & release). Utsnitt (vecka -2). Alltid kort copy.</div>
+                  </div>
+                </div>
+              </Card>
+            </div>
+          </div>
+        ),
+      },
+
+      {
+        id: "ops",
+        kicker: "EXECUTION",
+        title: "Operativ checklista (så ni faktiskt gör det)",
+        subtitle:
+          "Det här är den tråkiga delen som gör att den coola delen fungerar. Gör detta en gång, så blir allt lätt.",
+        body: () => (
+          <div className="mt-8 grid gap-6 md:grid-cols-12">
+            <div className="md:col-span-7">
+              <Card className="p-6 md:p-7">
+                <div className="text-xs tracking-[0.2em]" style={{ color: THEME.text4 }}>
+                  FÖRBERED 7 DAGAR INNAN VECKA −3
+                </div>
+                <div className="mt-4">
+                  <Checklist
+                    items={[
+                      "Bygg en assetbank: 1 hel artwork, 6–12 utsnitt, 3–5 rök-loopar, 2–3 logga-only frames.",
+                      "Export: 1080×1920 (stories), 1080×1350 (feed), 1080×1080 (grid), 1920×1080 (YouTube/press).",
+                      "Sätt copybank i en Notion/Google Doc: 20 rader max. Inga emojis. Inga förklaringar.",
+                      "Lägg allt i en schemaläggare (Meta Business Suite) så ni inte improviserar sönder identiteten.",
+                      "Pinned post-plan: 1 reel (release) + 1 artwork (vecka -1).",
+                    ]}
+                  />
+                </div>
+              </Card>
+            </div>
+            <div className="md:col-span-5">
+              <Card className="p-6">
+                <div className="text-xs tracking-[0.2em]" style={{ color: THEME.text4 }}>
+                  48H KPI (HÅRD MÄTNING)
+                </div>
+                <div className="mt-4 space-y-3 text-sm" style={{ color: THEME.text3 }}>
+                  {[
+                    "Reel retention: sikta på att folk ser 70–90% (korta klipp vinner).",
+                    "Saves + Shares: viktigare än likes. Det är ‘signal sprids’-mätaren.",
+                    "Link clicks / pre-save: allt före release är friktionstest.",
+                    "Kommentarer: svara kort, kallt, konsekvent. Aldrig förklarande romaner.",
+                  ].map((t, i) => (
+                    <div
+                      key={i}
+                      className="rounded-xl border px-4 py-3"
+                      style={{ borderColor: THEME.border, background: THEME.panel2 }}
+                    >
+                      {t}
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-4 text-xs" style={{ color: THEME.text4 }}>
+                  Stark åsikt: om retentionen suger är det inte algoritmen — det är att er reel inte har en brutal öppning.
+                </div>
+              </Card>
+            </div>
+          </div>
+        ),
+      },
+
+      {
+        id: "final",
+        kicker: "SLUTKOMMANDO",
+        title: "Publicera som en maskin",
+        subtitle:
+          "Ni har ett starkt språk. Nu handlar det om repetition och tajming. Folk behöver höra signalen fler gånger än du tror — och de kommer tacka dig efteråt.",
+        body: (img) => (
+          <div className="mt-8 grid gap-6 md:grid-cols-12">
+            <div className="md:col-span-7">
+              <Card className="p-6 md:p-7">
+                <div className="text-xs tracking-[0.2em]" style={{ color: THEME.text4 }}>
+                  EN ENKEL REGLA
+                </div>
+                <div className="mt-3 text-xl md:text-2xl font-semibold tracking-tight" style={{ color: THEME.text }}>
+                  Om det känns för repetitivt för dig — är det precis lagom för publiken.
+                </div>
+
+                <div className="mt-6 grid gap-4">
+                  <div className="rounded-2xl border p-5" style={{ borderColor: THEME.border, background: THEME.panel2 }}>
+                    <div className="text-sm font-semibold" style={{ color: THEME.text2 }}>
+                      Daglig micro-rutin (vecka -1 & release)
+                    </div>
+                    <div className="mt-2 text-sm leading-relaxed" style={{ color: THEME.text3 }}>
+                      1) Story: datum/symbol. 2) Reel: 10–12s drop. 3) Kommentar: 1 kall rad. 4) Repost reaktioner.
+                    </div>
+                  </div>
+                  <div className="rounded-2xl border p-5" style={{ borderColor: THEME.border, background: THEME.panel2 }}>
+                    <div className="text-sm font-semibold" style={{ color: THEME.text2 }}>
+                      Copy (default)
+                    </div>
+                    <div className="mt-2 text-sm leading-relaxed" style={{ color: THEME.text3 }}>
+                      Titel + datum. Eller: “TRANSMISSION RECEIVED.” Punkt.
+                    </div>
+                  </div>
+                </div>
+              </Card>
+            </div>
+
+            <div className="md:col-span-5">
+              <Card className="p-3">
+                <div
+                  className="aspect-square w-full overflow-hidden rounded-xl border"
+                  style={{ borderColor: THEME.border, background: THEME.panel2 }}
+                >
+                  {img.dataUrl ? (
+                    <img
+                      src={img.dataUrl}
+                      alt={img.fileName || "Key visual"}
+                      className="h-full w-full object-cover"
+                      crossOrigin="anonymous"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center p-8 text-center">
+                      <div>
+                        <div className="text-sm" style={{ color: THEME.text3 }}>
+                          Ladda upp nyckelbilden.
+                        </div>
+                        <div className="mt-2 text-xs" style={{ color: THEME.text4 }}>
+                          Den här sliden är byggd för att bära er grid/estetik.
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+                <div className="mt-3 px-2 pb-2 text-xs" style={{ color: THEME.text4 }}>
+                  Pro-tip: gör 9-post grid-release (den här) på vecka -1 eller dag 0, och klipp samtidigt ut 3 rutor som story-teasers.
+                </div>
+              </Card>
+            </div>
+          </div>
+        ),
+      },
+    ],
+    []
+  );
+
+  const clamp = (n) => Math.max(0, Math.min(slides.length - 1, n));
+  const next = () => setIdx((v) => clamp(v + 1));
+  const prev = () => setIdx((v) => clamp(v - 1));
+
+  const exportPdf = async () => {
+    if (!img.dataUrl) {
+      alert("Ladda upp nyckelbilden först — PDF:en ska bära den.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const { html2canvas, jsPDF } = await loadPdfDeps();
+
+      // A4 landscape för “deck-känsla”.
+      const pdf = new jsPDF({ orientation: "landscape", unit: "pt", format: "a4" });
+      const pageW = pdf.internal.pageSize.getWidth();
+      const pageH = pdf.internal.pageSize.getHeight();
+
+      const margin = 28;
+      const targetW = pageW - margin * 2;
+      const targetH = pageH - margin * 2;
+
+      const nodes = hiddenRefs.current.filter(Boolean);
+
+      for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((r) => setTimeout(r, 50));
+
+        // eslint-disable-next-line no-await-in-loop
+        const canvas = await html2canvas(node, {
+          backgroundColor: THEME.bg,
+          scale: 2,
+          useCORS: true,
+          allowTaint: true,
+          logging: false,
+        });
+
+        const imgData = canvas.toDataURL("image/png", 1.0);
+        const cW = canvas.width;
+        const cH = canvas.height;
+
+        const ratio = Math.min(targetW / cW, targetH / cH);
+        const drawW = cW * ratio;
+        const drawH = cH * ratio;
+        const x = (pageW - drawW) / 2;
+        const y = (pageH - drawH) / 2;
+
+        if (i > 0) pdf.addPage();
+
+        // Subtil “print frame”
+        pdf.setDrawColor(40, 40, 40);
+        pdf.setLineWidth(1);
+        pdf.roundedRect(margin - 8, margin - 8, targetW + 16, targetH + 16, 12, 12);
+
+        pdf.addImage(imgData, "PNG", x, y, drawW, drawH, undefined, "FAST");
+
+        pdf.setTextColor(170);
+        pdf.setFontSize(9);
+        pdf.text(
+          `${i + 1}/${nodes.length}  •  ${img.fileName || "key-visual"}`,
+          pageW - margin,
+          pageH - 12,
+          { align: "right" }
+        );
+      }
+
+      pdf.save(`NorthStarRising_ReleaseDeck_${new Date().toISOString().slice(0, 10)}.pdf`);
+    } catch (e) {
+      console.error(e);
+      alert("PDF-export misslyckades. Testa igen (och säkerställ att bilden är laddad).\n\n" + (e?.message || ""));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <SlideShell>
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-3">
+            <div className="rounded-2xl border p-3" style={{ borderColor: THEME.border, background: THEME.panel2 }}>
+              <Radio className="h-5 w-5" style={{ color: THEME.text2 }} />
+            </div>
+            <div>
+              <div className="text-sm" style={{ color: THEME.text3 }}>
+                Körbar deck
+              </div>
+              <div className="text-xs" style={{ color: THEME.text4 }}>
+                Navigera med pilarna eller piltangenter.
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              onClick={exportPdf}
+              className="inline-flex items-center gap-2 rounded-2xl border px-4 py-3 text-sm disabled:opacity-40"
+              style={{ borderColor: THEME.border, background: THEME.panel2, color: THEME.text2 }}
+              disabled={busy}
+              title={img.dataUrl ? "Exportera hela presentationen till PDF" : "Ladda upp nyckelbilden först"}
+            >
+              <FileDown className="h-4 w-4" style={{ color: THEME.text2 }} />
+              {busy ? "Exporterar…" : "Exportera PDF"}
+            </button>
+
+            <button
+              onClick={prev}
+              className="inline-flex items-center gap-2 rounded-2xl border px-4 py-3 text-sm disabled:opacity-40"
+              style={{ borderColor: THEME.border, background: THEME.panel2, color: THEME.text2 }}
+              disabled={idx === 0}
+            >
+              <ChevronLeft className="h-4 w-4" style={{ color: THEME.text2 }} />
+              Föregående
+            </button>
+
+            <button
+              onClick={next}
+              className="inline-flex items-center gap-2 rounded-2xl border px-4 py-3 text-sm disabled:opacity-40"
+              style={{ borderColor: THEME.border, background: THEME.panel2, color: THEME.text2 }}
+              disabled={idx === slides.length - 1}
+            >
+              Nästa
+              <ChevronRight className="h-4 w-4" style={{ color: THEME.text2 }} />
+            </button>
+          </div>
+        </div>
+
+        <div
+          className="flex items-center justify-between rounded-2xl border px-5 py-3"
+          style={{ borderColor: THEME.border, background: THEME.panel2 }}
+        >
+          <div className="text-sm" style={{ color: THEME.text3 }}>
+            Slide <span className="font-semibold" style={{ color: THEME.text }}>{idx + 1}</span> / {slides.length}
+          </div>
+          <div className="text-xs" style={{ color: THEME.text4 }}>
+            Key image: {img.fileName || "(inte laddad)"}
+          </div>
+        </div>
+
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={slides[idx].id}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.25 }}
+          >
+            <SlideBody slide={slides[idx]} img={img} />
+          </motion.div>
+        </AnimatePresence>
+
+        <div className="text-xs leading-relaxed" style={{ color: THEME.text4 }}>
+          <span style={{ color: THEME.text4 }}>Snabbt användartips:</span> Exportera PDF när ni laddat upp nyckelbilden.
+          PDF:en blir en säljande “one-deck” ni kan skicka till team, label, press eller hålla som intern handbok.
+        </div>
+      </div>
+
+      <KeyNav onPrev={prev} onNext={next} />
+
+      {/* OFFSCREEN RENDER för PDF-export — syns inte men fångas av html2canvas */}
+      <div className="fixed -left-[10000px] top-0 w-[1200px]" aria-hidden="true">
+        {slides.map((s, i) => (
+          <div
+            key={s.id}
+            ref={(el) => (hiddenRefs.current[i] = el)}
+            style={{ background: THEME.bg, color: THEME.text }}
+          >
+            <div className="p-10">
+              <div className="mb-6 flex items-center justify-between">
+                <div>
+                  <div className="text-xs tracking-[0.2em]" style={{ color: THEME.text4 }}>
+                    NORTH STAR RISING
+                  </div>
+                  <div className="mt-1 text-base font-semibold" style={{ color: THEME.text2 }}>
+                    Releaseplan & Social Media Deck
+                  </div>
+                </div>
+                <div className="text-xs" style={{ color: THEME.text4 }}>
+                  {new Date().toISOString().slice(0, 10)}
+                </div>
+              </div>
+
+              <SlideBody slide={s} img={img} />
+
+              <div className="mt-6 flex items-center justify-between text-xs" style={{ color: THEME.text4 }}>
+                <div>Cold Protocol • Active</div>
+                <div>
+                  {i + 1}/{slides.length}
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </SlideShell>
+  );
+}
+
+function KeyNav({ onPrev, onNext }) {
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "ArrowLeft") onPrev();
+      if (e.key === "ArrowRight") onNext();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onPrev, onNext]);
+  return null;
+}

--- a/apps/storyboard/dist/index.html
+++ b/apps/storyboard/dist/index.html
@@ -1,0 +1,2159 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8" />
+  <!--
+    Remove maximum‑scale from the viewport meta tag to allow users to zoom and respect their default text
+    size preferences. See web.dev guidance about not restricting zoom【0863740095805868†L142-L190】.
+  -->
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>AudioVisual Storyboard – Concept Vangård</title>
+  <meta name="theme-color" content="#1a1d29" />
+  <meta name="description" content="Professional storyboard creation tool for audiovisual projects" />
+  <link rel="manifest" href="manifest.webmanifest" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+  <link rel="apple-touch-icon" sizes="180x180" href="icons/icon-192.png" />
+  <!-- Preconnect to font domains for faster font loading -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      /* Modern dark theme with purple/blue accents */
+      /* Updated color palette for a fresher look */
+      --bg: #0e141f;
+      --bg-elevated: #1b2232;
+      --bg-surface: #253046;
+      --bg-hover: #2d3a52;
+      --bg-selected: #3a4871;
+      --border: #2e3e5c;
+      --text-primary: #e3e9f8;
+      --text-secondary: #9ba7c2;
+      --text-muted: #6f7a96;
+      --accent-primary: #8b5cf6;
+      --accent-secondary: #0ea5e9;
+      --accent-gradient: linear-gradient(135deg, #8b5cf6, #0ea5e9);
+      --success: #22c55e;
+      --warning: #f59e0b;
+      --error: #ef4444;
+      --radius: 12px;
+      --radius-lg: 16px;
+      --gap: 12px;
+      --transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      --shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+      --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.3);
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    html, body {
+      height: 100%;
+      background: var(--bg);
+      color: var(--text-primary);
+      font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+      font-size: 14px;
+      line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      /* Prevent horizontal overscroll/back navigation on touch devices and restrict gestures to vertical scrolling */
+      overscroll-behavior-x: contain;
+      touch-action: pan-y;
+    }
+
+    a {
+      color: var(--accent-secondary);
+      text-decoration: none;
+      transition: var(--transition);
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    button {
+      cursor: pointer;
+      transition: var(--transition);
+      font-family: inherit;
+      font-weight: 500;
+      border: none;
+      outline: none;
+      position: relative;
+      overflow: hidden;
+    }
+
+    button:active {
+      transform: scale(0.98);
+    }
+
+    button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .app {
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+      /* contain horizontal overscroll inside the app to reduce accidental side swiping */
+      overscroll-behavior-x: contain;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.75rem 1rem;
+      background: var(--bg-elevated);
+      border-bottom: 1px solid var(--border);
+      position: sticky;
+      top: 0;
+      /* Increase z-index so the sticky header always stays above scene cards. 10 was not sufficient on some devices */
+      z-index: 100;
+      flex-wrap: wrap;
+      box-shadow: var(--shadow);
+    }
+
+    header h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      flex: 1;
+      min-width: 140px;
+      background: var(--accent-gradient);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .brand {
+      font-size: 0.875rem;
+      color: var(--text-secondary);
+      font-weight: 500;
+    }
+
+    .nav {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .nav button {
+      background: var(--bg-surface);
+      color: var(--text-secondary);
+      padding: 0.5rem 1rem;
+      border-radius: var(--radius);
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: var(--transition);
+    }
+
+    .nav button:hover {
+      background: var(--bg-hover);
+      color: var(--text-primary);
+    }
+
+    .nav button[aria-current="page"] {
+      background: var(--accent-gradient);
+      color: white;
+    }
+
+    .toolbar {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    /* Buttons were slightly oversized on mobile, leading to a cluttered UI.
+       Reduce font-size and padding to make the interface feel lighter and
+       consume less vertical space. */
+    .btn {
+      background: var(--bg-surface);
+      color: var(--text-primary);
+      padding: 0.4rem 0.75rem;
+      border-radius: var(--radius);
+      font-size: 0.75rem;
+      font-weight: 500;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      transition: var(--transition);
+      border: 1px solid var(--border);
+    }
+
+    .btn:hover {
+      background: var(--bg-hover);
+      transform: translateY(-1px);
+      box-shadow: var(--shadow);
+    }
+
+    .btn.primary {
+      background: var(--accent-gradient);
+      color: white;
+      border: none;
+    }
+
+    .btn.ghost {
+      background: transparent;
+      border: 1px solid var(--border);
+    }
+
+    .badge {
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 0.25rem 0.75rem;
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+      background: var(--bg-surface);
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+
+    main {
+      flex: 1;
+      padding: 1.5rem;
+      overflow-y: auto;
+    }
+
+    .section {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      /* tighten vertical space by reducing padding */
+      padding: 1.25rem;
+      margin-bottom: 1.25rem;
+      box-shadow: var(--shadow);
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(1, 1fr);
+      gap: 1.5rem;
+    }
+
+    @media (min-width: 680px) {
+      .grid {
+        grid-template-columns: repeat(2, 1fr);
+      }
+    }
+
+    @media (min-width: 1024px) {
+      .grid {
+        grid-template-columns: repeat(3, 1fr);
+      }
+    }
+
+    .card {
+      background: var(--bg-surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+      transition: var(--transition);
+      /* Make cards participate in stacking context so they don't unexpectedly overlay the sticky header */
+      position: relative;
+      z-index: 1;
+    }
+
+    .card:hover {
+      transform: translateY(-2px);
+      box-shadow: var(--shadow-lg);
+    }
+
+    .card.selected {
+      outline: 2px solid var(--accent-primary);
+      box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.2);
+    }
+
+    .card header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      background: var(--accent-gradient);
+      color: white;
+      padding: 0.75rem 1rem;
+    }
+
+    .card .left {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .card .num {
+      font-weight: 600;
+    }
+
+    .card .actions {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    /* Hide action icons when the card is collapsed to prevent layout overflow on small screens. Users can expand the card to access these actions. */
+    .card.collapsed .actions {
+      display: none;
+    }
+
+    .card .icon {
+      background: rgba(255, 255, 255, 0.2);
+      color: white;
+      border: none;
+      width: 32px;
+      height: 32px;
+      border-radius: 8px;
+      font-size: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: var(--transition);
+    }
+
+    .card .icon:hover {
+      background: rgba(255, 255, 255, 0.3);
+    }
+
+    .card.locked {
+      opacity: 0.85;
+      filter: saturate(0.7);
+    }
+
+    /* collapsed scenes reduce vertical height; body hidden when collapsed */
+    .card.collapsed .body { display: none; }
+    /* When collapsed, shrink image height further to 100px to save vertical space */
+    .card.collapsed .img { height: 100px; }
+
+    /* Reduce default image height from 180px to 160px to compress card height. */
+    .img {
+      height: 160px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--bg);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .img img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: none;
+    }
+
+    .placeholder {
+      font-size: 3rem;
+      color: var(--text-muted);
+    }
+
+    .body {
+      padding: 1rem;
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    label {
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+      display: block;
+      margin-bottom: 0.25rem;
+      font-weight: 500;
+    }
+
+    input[type="text"],
+    input[type="number"],
+    select,
+    textarea {
+      width: 100%;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      color: var(--text-primary);
+      padding: 0.5rem 0.75rem;
+      border-radius: var(--radius);
+      font-family: inherit;
+      font-size: 0.875rem;
+      transition: var(--transition);
+    }
+
+    input:focus,
+    select:focus,
+    textarea:focus {
+      outline: none;
+      border-color: var(--accent-primary);
+      box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
+    }
+
+    textarea {
+      resize: vertical;
+      min-height: 56px;
+    }
+
+    input,
+    textarea,
+    button {
+      min-height: 40px;
+    }
+
+    /* selection bar */
+    .selbar {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      align-items: center;
+      margin: 1rem 0;
+      padding: 1rem;
+      border: 1px dashed var(--border);
+      border-radius: var(--radius);
+      background: var(--bg);
+    }
+
+    /* Hide selbar when it has the hidden class. Used on small screens to declutter the UI. */
+    #selbar.hidden {
+      display: none;
+    }
+
+    .selbar input[type="text"] {
+      min-width: 120px;
+    }
+
+    .selbar textarea {
+      min-width: 200px;
+      min-height: 40px;
+    }
+
+    .selbar .split {
+      width: 1px;
+      background: var(--border);
+      height: 32px;
+    }
+
+    /* chips */
+    .chips {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .chip {
+      border: 1px solid var(--border);
+      background: var(--bg);
+      color: var(--text-primary);
+      border-radius: 999px;
+      padding: 0.25rem 0.75rem;
+      font-size: 0.75rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+
+    /* quick tags */
+    .qtags {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      margin-top: 0.5rem;
+    }
+
+    .qtags .qt {
+      border: 1px solid currentColor;
+      background: transparent;
+      border-radius: 999px;
+      padding: 0.2rem 0.6rem;
+      font-size: 0.68rem;
+      line-height: 1.2;
+      transition: var(--transition);
+    }
+
+    .qtags .qt:hover {
+      background: var(--bg-hover);
+      opacity: 0.85;
+    }
+
+    .qtags .qt[data-cat="camera"] {
+      color: var(--success);
+      border-color: var(--success);
+    }
+
+    .qtags .qt[data-cat="light"] {
+      color: var(--warning);
+      border-color: var(--warning);
+    }
+
+    .qtags .qt[data-cat="vfx"] {
+      color: var(--accent-primary);
+      border-color: var(--accent-primary);
+    }
+
+    /* timeline */
+    .timeline-wrap {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .timeline-toolbar {
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .timeline {
+      position: relative;
+      display: block;
+      overflow: auto;
+      padding: 1rem;
+      background: var(--bg-surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      white-space: nowrap;
+      height: 260px;
+      /* allow both horizontal and vertical scrolling gestures inside the timeline */
+      touch-action: pan-x pan-y;
+    }
+
+    .beat {
+      position: absolute;
+      top: 4px;
+      bottom: 4px;
+      width: 1px;
+      background: var(--border);
+      opacity: 0.5;
+    }
+
+    .lane-line {
+      position: absolute;
+      left: 0;
+      right: 0;
+      height: 1px;
+      background: var(--border);
+    }
+
+    .lane-label {
+      position: absolute;
+      left: 6px;
+      font-size: 0.625rem;
+      color: var(--text-muted);
+    }
+
+    .marker {
+      position: absolute;
+      top: 4px;
+      bottom: 4px;
+      width: 2px;
+      background: var(--warning);
+    }
+
+    .marker::after {
+      content: attr(data-label);
+      position: absolute;
+      top: -10px;
+      left: 4px;
+      font-size: 0.625rem;
+      background: var(--bg-elevated);
+      padding: 2px 4px;
+      border-radius: 6px;
+      color: var(--warning);
+      border: 1px solid var(--border);
+      white-space: nowrap;
+    }
+
+    .snap {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 2px;
+      background: var(--error);
+      opacity: 0.9;
+      pointer-events: none;
+    }
+
+    .block {
+      position: absolute;
+      height: 72px;
+      border: 2px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--bg);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 8px;
+      user-select: none;
+      transition: var(--transition);
+    }
+
+    .block:hover {
+      background: var(--bg-hover);
+    }
+
+    .block .title {
+      font-size: 0.75rem;
+    }
+
+    .block .dur {
+      position: absolute;
+      bottom: 4px;
+      right: 6px;
+      font-size: 0.6875rem;
+      color: var(--text-secondary);
+    }
+
+    .block.drag {
+      outline: 2px dashed var(--accent-secondary);
+      opacity: 0.95;
+    }
+
+    .block.overlap {
+      outline: 2px solid var(--warning);
+    }
+
+    .block.locked {
+      outline: 2px solid var(--text-muted);
+      background: var(--bg);
+    }
+
+    /* overview */
+    .ov-toolbar {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    .ov-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 0.75rem;
+    }
+
+    @media (min-width: 780px) {
+      .ov-grid {
+        grid-template-columns: repeat(6, 1fr);
+      }
+    }
+
+    .thumb {
+      aspect-ratio: 16/9;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--text-muted);
+      background-size: cover;
+      background-position: center;
+      transition: var(--transition);
+    }
+
+    .thumb:hover {
+      transform: scale(1.02);
+      box-shadow: var(--shadow);
+    }
+
+    /* Side thumbnail navigation for scenes */
+    .thumb-nav {
+      position: fixed;
+      right: 10px;
+      width: 60px;
+      max-height: 70vh;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      z-index: 9;
+    }
+    .thumb-nav img {
+      width: 100%;
+      height: auto;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      object-fit: cover;
+      cursor: pointer;
+      transition: transform 0.2s;
+    }
+    .thumb-nav img:hover {
+      transform: scale(1.1);
+    }
+
+    /* Responsive adjustments for thumbnail navigation on mobile: position at bottom as a horizontal gallery */
+    @media (max-width: 900px) {
+      .thumb-nav {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        top: auto;
+        width: 100%;
+        height: 64px;
+        padding: 0.5rem;
+        flex-direction: row;
+        align-items: center;
+        justify-content: flex-start;
+        overflow-x: auto;
+        overflow-y: hidden;
+        gap: 0.5rem;
+        background: var(--bg-elevated);
+        border-top: 1px solid var(--border);
+      }
+      .thumb-nav img {
+        width: 56px;
+        height: 100%;
+        border-radius: var(--radius);
+        border: 1px solid var(--border);
+        flex-shrink: 0;
+      }
+      .thumb-nav img:hover {
+        transform: scale(1.05);
+      }
+    }
+
+    /* Prevent cards from sliding under the sticky header when scrolled into view */
+    .card {
+      scroll-margin-top: 96px;
+    }
+
+    /* Add spacing to the scenes view to ensure cards do not overlap the sticky header */
+    #view-scenes {
+      padding-top: 1rem;
+    }
+
+    /* On small screens, add bottom padding to scenes so that the floating thumbnail bar doesn't cover content */
+    @media (max-width: 900px) {
+      #view-scenes {
+        padding-bottom: 80px;
+      }
+    }
+
+    /* Actions menu toggle and responsive behaviour */
+    #actions.hidden {
+      display: none !important;
+    }
+    /* Hide menu button by default; visible only on narrow screens */
+    #toggle-actions {
+      display: none;
+    }
+    @media (max-width: 900px) {
+      #toggle-actions {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin-left: 0.5rem;
+      }
+      /* Hide the actions container by default on mobile; toggled via JS */
+      #actions {
+        display: none;
+      }
+      #actions:not(.hidden) {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-top: 0.5rem;
+      }
+    }
+    @media (min-width: 901px) {
+      /* On larger screens, always show actions and hide menu button */
+      #toggle-actions {
+        display: none;
+      }
+      #actions {
+        display: flex;
+      }
+    }
+
+    .toast {
+      position: fixed;
+      left: 50%;
+      bottom: 1.5rem;
+      transform: translateX(-50%);
+      background: var(--bg-elevated);
+      color: var(--text-primary);
+      border-radius: var(--radius);
+      padding: 0.75rem 1.5rem;
+      opacity: 0;
+      transition: opacity 0.25s;
+      z-index: 999;
+      border: 1px solid var(--border);
+      box-shadow: var(--shadow-lg);
+    }
+
+    .toast.show {
+      opacity: 1;
+    }
+
+    /* Loading animation */
+    .loading {
+      display: inline-block;
+      width: 20px;
+      height: 20px;
+      border: 3px solid rgba(255, 255, 255, 0.3);
+      border-radius: 50%;
+      border-top-color: white;
+      animation: spin 1s ease-in-out infinite;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    /* Material Icons */
+    .material-icons {
+      font-size: 1.25rem;
+      vertical-align: middle;
+    }
+
+    /* Focus styles for keyboard navigation */
+    button:focus,
+    input:focus,
+    select:focus,
+    textarea:focus {
+      outline: 2px solid var(--accent-secondary);
+      outline-offset: 2px;
+    }
+
+    /* Responsive adjustments */
+    @media (max-width: 768px) {
+      header {
+        padding: 0.75rem 1rem;
+      }
+
+      header h1 {
+        font-size: 1.25rem;
+      }
+
+      main {
+        padding: 1rem;
+      }
+
+      .section {
+        padding: 1rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <header>
+      <div>
+        <h1>AudioVisual Storyboard</h1>
+        <div class="brand">by Concept Vangård</div>
+      </div>
+      <nav class="nav" role="tablist">
+        <button id="tab-scenes" aria-current="page">Scener</button>
+        <button id="tab-timeline">Tidslinje</button>
+        <button id="tab-overview">Översikt</button>
+        <button id="tab-export">Export</button>
+      </nav>
+      <!-- Collapsible actions menu on mobile -->
+      <button id="toggle-actions" class="btn ghost menu-btn" aria-label="Visa eller dölj verktyg">
+        <span class="material-icons">menu</span>
+      </button>
+      <div id="actions" class="toolbar actions">
+        <button id="btn-add" class="btn primary" aria-label="Lägg till ny scen">
+          <span class="material-icons">add</span> Ny scen
+        </button>
+        <button id="btn-import-images" class="btn" aria-label="Batchimportera bilder">
+          <span class="material-icons">photo_library</span> Batch-import bilder
+        </button>
+        <input id="file-import-images" type="file" accept="image/*,video/*" multiple style="display:none" />
+        <button id="btn-import-json" class="btn" aria-label="Importera JSON">
+          <span class="material-icons">upload_file</span> Import JSON
+        </button>
+        <input id="file-import-json" type="file" accept="application/json" style="display:none" />
+      </div>
+    </header>
+
+    <main>
+      <!-- Scenes -->
+      <section id="view-scenes" class="section">
+        <div class="toolbar" style="margin-bottom:1rem">
+          <span class="badge">Scener: <b id="proj-count">0</b></span>
+          <!-- Toggle button to show/hide bulk action tools on small screens -->
+          <button id="toggle-selbar" class="btn ghost" aria-label="Visa eller dölj urvalsverktyg">Verktyg</button>
+          <div style="flex:1"></div>
+          <button id="btn-export-json-top" class="btn ghost" aria-label="Exportera JSON">
+            <span class="material-icons">download</span> Export JSON
+          </button>
+        </div>
+        <div class="selbar" id="selbar">
+          <span class="badge">Markerade: <b id="sel-count">0</b></span>
+          <button class="btn" id="sel-all">Markera alla</button>
+          <button class="btn" id="sel-none">Rensa markering</button>
+          <div class="split"></div>
+
+          <label class="badge">Längd <input id="bulk-dur" type="text" placeholder="t.ex. 8s / 1:20" style="margin-left:6px"></label>
+          <button class="btn" id="bulk-set-dur">Sätt längd</button>
+          <div class="split"></div>
+
+          <label class="badge">Kamera
+            <select id="bulk-cam" style="margin-left:6px">
+              <option>Wide</option><option selected>Medium</option><option>Close</option><option>Dutch</option><option>Top</option><option>Low</option>
+            </select>
+          </label>
+          <button class="btn" id="bulk-set-cam">Sätt kamera</button>
+          <div class="split"></div>
+
+          <label class="badge">tags.camera <input id="bulk-tags-camera" type="text" placeholder="ex: low angle, handheld" style="margin-left:6px"></label>
+          <label class="badge">tags.light <input id="bulk-tags-light" type="text" placeholder="ex: backlight, smoke"></label>
+          <label class="badge">tags.vfx <input id="bulk-tags-vfx" type="text" placeholder="ex: sparks, particles"></label>
+          <button class="btn" id="bulk-add-tags">+ Lägg till</button>
+          <button class="btn" id="bulk-replace-tags">↺ Ersätt</button>
+          <button class="btn" id="bulk-clear-tags">✕ Rensa</button>
+          <div class="split"></div>
+
+          <label class="badge">Lane
+            <select id="bulk-lane" style="margin-left:6px">
+              <option value="0" selected>0</option><option value="1">1</option><option value="2">2</option>
+            </select>
+          </label>
+          <button class="btn" id="bulk-set-lane">Sätt lane</button>
+          <div class="split"></div>
+
+          <button class="btn" id="bulk-dup">📋 Duplicera markerade</button>
+          <button class="btn" id="bulk-del">🗑️ Ta bort markerade</button>
+          <div class="split"></div>
+          <button class="btn" id="bulk-lock">🔒 Lås markerade</button>
+          <button class="btn" id="bulk-unlock">🔓 Lås upp markerade</button>
+        </div>
+
+        <div class="qtags" id="qtags">
+          <span class="badge">Snabbtaggar:</span>
+          <button class="qt" data-cat="camera" data-val="low angle">camera: low angle</button>
+          <button class="qt" data-cat="camera" data-val="handheld">camera: handheld</button>
+          <button class="qt" data-cat="light" data-val="backlight">light: backlight</button>
+          <button class="qt" data-cat="light" data-val="smoke">light: smoke</button>
+          <button class="qt" data-cat="vfx" data-val="smoke">vfx: smoke</button>
+          <button class="qt" data-cat="vfx" data-val="sparks">vfx: sparks</button>
+          <button class="qt" data-cat="vfx" data-val="particles">vfx: particles</button>
+          <button class="qt" data-cat="vfx" data-val="laser">vfx: laser</button>
+        </div>
+
+        <div class="toolbar" style="margin:1rem 0">
+          <label class="badge">Sortering (Visning)
+            <select id="sort-by" style="margin-left:6px">
+              <option value="start" selected>Start</option>
+              <option value="title">Titel</option>
+              <option value="duration">Längd</option>
+              <option value="camera">Kamera</option>
+            </select>
+          </label>
+          <label class="badge">Riktning
+            <select id="sort-dir" style="margin-left:6px">
+              <option value="asc" selected>Stigande</option>
+              <option value="desc">Fallande</option>
+            </select>
+          </label>
+        </div>
+
+        <div id="grid" class="grid"></div>
+        <div id="empty" class="section" style="display:none;text-align:center">Inga scener ännu.</div>
+        <!-- Thumbnail navigation for quick scene access -->
+      </section>
+
+      <!-- Timeline -->
+      <section id="view-timeline" class="section" style="display:none">
+        <div class="timeline-wrap">
+          <div class="timeline-toolbar">
+            <label class="badge">BPM <input id="bpm" type="number" min="30" max="300" value="120" style="width:80px;margin-left:6px"></label>
+            <div class="audio-bar">
+              <input id="audio-file" type="file" accept="audio/*">
+              <button id="play" class="btn">▶/⏸</button>
+              <button id="stop" class="btn">⏹</button>
+              <input id="scrub" type="range" min="0" max="0" value="0" style="width:220px">
+              <span class="badge" id="cur-time">0:00</span> / <span class="badge" id="dur-time">0:00</span>
+            </div>
+            <div style="flex:1"></div>
+            <button class="btn" id="tl-zoom-out">−</button>
+            <button class="btn" id="tl-zoom-in">+</button>
+            <button class="btn" id="tl-fit">Auto-fit längder</button>
+            <button class="btn" id="tl-resolve">Auto-resolve överlapp</button>
+            <button class="btn" id="tl-snap-toggle">Snap: Beat</button>
+            <label class="badge">Grid
+              <input id="grid-hard" type="checkbox" style="margin-left:6px"> Hard
+            </label>
+            <label class="badge">Quantize
+              <select id="grid-quant" style="margin-left:6px">
+                <option value="1" selected>1 beat</option>
+                <option value="0.5">1/2 beat</option>
+                <option value="0.25">1/4 beat</option>
+              </select>
+            </label>
+            <label class="badge">Auto-reflow
+              <input id="reflow-toggle" type="checkbox" checked style="margin-left:6px">
+            </label>
+          </div>
+
+          <details style="margin-top:6px">
+            <summary class="badge" style="cursor:pointer">Lane-inställningar (namn & färg)</summary>
+            <div id="lanes-box" style="margin-top:8px"></div>
+          </details>
+
+          <div id="timeline" class="timeline"></div>
+          <small class="badge" style="margin-top:6px">Tips: **Shift-drag** snäpper till närmaste marker. **Ctrl** = till nästa, **Alt** = till föregående. Mobil: växla "Snap: …".</small>
+
+          <div class="toolbar" style="margin-top:10px">
+            <label class="badge">Marker label <input id="marker-label" type="text" style="width:160px;margin-left:6px" placeholder="ex: Verse A"></label>
+            <label class="badge">Typ
+              <select id="marker-type">
+                <option>Section</option><option>Verse</option><option>Chorus</option><option>Bridge</option><option>Custom</option>
+              </select>
+            </label>
+            <label class="badge">Tid <input id="marker-time" type="text" style="width:80px;margin-left:6px" placeholder="mm:ss eller sek"></label>
+            <button class="btn" id="marker-add-cur">+ Add @ Current</button>
+            <button class="btn" id="marker-add-manual">+ Add Manual</button>
+            <button class="btn" id="marker-align">Align Scenes → Markers</button>
+            <button class="btn" id="marker-clear">Rensa markers</button>
+          </div>
+        </div>
+      </section>
+
+      <!-- Overview -->
+      <section id="view-overview" class="section" style="display:none">
+        <div class="ov-toolbar">
+          <label class="badge">Filter
+            <select id="filter-cat" style="margin-left:6px">
+              <option value="title">Titel</option>
+              <option value="description">Beskrivning</option>
+              <option value="tags.camera">tags.camera</option>
+              <option value="tags.light">tags.light</option>
+              <option value="tags.vfx" selected>tags.vfx</option>
+            </select>
+          </label>
+          <input id="filter-text" type="text" placeholder="t.ex. smoke" style="width:160px">
+          <div style="flex:1"></div>
+          <button class="btn" id="ov-prev">◀</button>
+          <span class="badge" id="ov-page">1 / 1</span>
+          <button class="btn" id="ov-next">▶</button>
+        </div>
+        <div id="ov-grid" class="ov-grid" style="margin-top:10px"></div>
+      </section>
+
+      <!-- Export -->
+      <section id="view-export" class="section" style="display:none">
+        <div class="toolbar" style="gap:8px;flex-wrap:wrap">
+          <label class="badge">Upplägg
+            <select id="pdf-layout">
+              <option value="1">1/sida</option>
+              <option value="2">2/sida</option>
+              <option value="4">4/sida</option>
+              <option value="6" selected>6/sida</option>
+              <option value="12">12/sida</option>
+            </select>
+          </label>
+          <label class="badge">Orientering
+            <select id="pdf-orientation">
+              <option value="portrait">Stående</option>
+              <option value="landscape" selected>Liggande</option>
+            </select>
+          </label>
+          <label class="badge">Rubrik
+            <input type="text" id="pdf-title" value="AudioVisual Storyboard — Musikvideo" style="width:220px;margin-left:6px">
+          </label>
+          <label class="badge"><input id="pdf-cover" type="checkbox" style="margin-right:6px">Inkludera sammanfattning (shot-list)</label>
+          <label class="badge"><input id="pdf-logo" type="checkbox" style="margin-right:6px">Visa logga i header</label>
+          <label class="badge"><input id="pdf-group" type="checkbox" style="margin-right:6px">Visa sektion (marker) per scen</label>
+          <div style="flex:1"></div>
+          <button class="btn primary" id="btn-export-pdf" aria-label="Exportera PDF">
+            <span class="material-icons">picture_as_pdf</span> Exportera PDF
+          </button>
+          <button class="btn" id="btn-export-json" aria-label="Exportera JSON">
+            <span class="material-icons">code</span> Exportera JSON
+          </button>
+          <button class="btn" id="btn-export-zip" aria-label="Exportera ZIP">
+            <span class="material-icons">archive</span> Export ZIP
+          </button>
+        </div>
+      </section>
+    </main>
+
+    <!-- Thumbnail navigation container moved outside scenes for better positioning -->
+    <div id="thumb-nav" class="thumb-nav" aria-label="Scenöversikt"></div>
+
+    <div class="toast" id="toast"></div>
+    <input id="file-hidden" type="file" accept="image/*,video/*" style="display:none" />
+  </div>
+
+<script defer>
+(function(){
+  'use strict';
+  /** Keys */
+  const STORAGE_KEY='sb_scenesv211sf';
+  const MARKERS_KEY='sb_markersv211sf';
+  const LANE_KEY='sb_lanesv211sf';
+
+  /** State */
+  let scenes=[], markers=[], laneMeta=[];
+  let selected=new Set();
+  let viewSortBy='start', viewSortDir='asc';
+  let audioCtx=null, audioBuf=null, audioSrc=null, audioStart=0, audioOffset=0, rafId=0;
+  let bpm=120, beatMs=500;
+  let timelinePxPerSec=30;
+  let laneCount=3;
+  let idb;
+  let snapEl=null;
+  let snapMode='beat'; // beat|marker
+  let hardGrid=false;
+  let quantDiv=1; // 1, 0.5, 0.25
+  let autoReflow=true;
+
+  /** Perf: debounced save + raf scheduler */
+  let _saveTimer=null;
+  function saveDebounced(){ clearTimeout(_saveTimer); _saveTimer=setTimeout(()=>save(), 200); }
+
+  let _rafScheduled=false, _needs={tl:false, sc:false, ov:false};
+  function scheduleRender({timeline=false, scenes=false, overview=false}={}){
+    _needs.tl = _needs.tl || timeline;
+    _needs.sc = _needs.sc || scenes;
+    _needs.ov = _needs.ov || overview;
+    if(_rafScheduled) return;
+    _rafScheduled=true;
+    requestAnimationFrame(()=>{
+      if(_needs.tl) renderTimeline();
+      if(_needs.sc) renderScenes();
+      if(_needs.ov) renderOverview();
+      _needs={tl:false, sc:false, ov:false};
+      _rafScheduled=false;
+    });
+  }
+
+  /** Marker cache */
+  let _markersSorted=null;
+  function markDirty(){ _markersSorted=null; }
+  function markersSorted(){
+    if(_markersSorted) return _markersSorted;
+    _markersSorted = [...markers].sort((a,b)=>a.t-b.t);
+    return _markersSorted;
+  }
+
+  /** DOM */
+  const $=s=>document.querySelector(s);
+  const el={
+    nav:{ scenes:$('#tab-scenes'), timeline:$('#tab-timeline'), overview:$('#tab-overview'), export:$('#tab-export') },
+    view:{ scenes:$('#view-scenes'), timeline:$('#view-timeline'), overview:$('#view-overview'), export:$('#view-export') },
+    add:$('#btn-add'), grid:$('#grid'), empty:$('#empty'), projCount:$('#proj-count'),
+    // selection
+    selCount:$('#sel-count'), selAll:$('#sel-all'), selNone:$('#sel-none'),
+  selbar:$('#selbar'), toggleSelbar:$('#toggle-selbar'),
+  // header actions menu
+  actions:$('#actions'), toggleActions:$('#toggle-actions'),
+    bulkDur:$('#bulk-dur'), bulkSetDur:$('#bulk-set-dur'),
+    bulkCam:$('#bulk-cam'), bulkSetCam:$('#bulk-set-cam'),
+    bulkCamTags:$('#bulk-tags-camera'), bulkLightTags:$('#bulk-tags-light'), bulkVfxTags:$('#bulk-tags-vfx'),
+    bulkAddTags:$('#bulk-add-tags'), bulkReplaceTags:$('#bulk-replace-tags'), bulkClearTags:$('#bulk-clear-tags'),
+    bulkLane:$('#bulk-lane'), bulkSetLane:$('#bulk-set-lane'),
+    bulkDup:$('#bulk-dup'), bulkDel:$('#bulk-del'),
+    bulkLock:$('#bulk-lock'), bulkUnlock:$('#bulk-unlock'),
+    qtags:$('#qtags'), sortBy:$('#sort-by'), sortDir:$('#sort-dir'),
+    // timeline
+    tl:$('#timeline'), bpm:$('#bpm'), audioFile:$('#audio-file'), play:$('#play'), stop:$('#stop'), scrub:$('#scrub'), curTime:$('#cur-time'), durTime:$('#dur-time'),
+    tlFit:$('#tl-fit'), tlResolve:$('#tl-resolve'), tlSnapToggle:$('#tl-snap-toggle'),
+    tlZoomIn:$('#tl-zoom-in'), tlZoomOut:$('#tl-zoom-out'),
+    gridHard:$('#grid-hard'), gridQuant:$('#grid-quant'),
+    reflowToggle:$('#reflow-toggle'),
+    // markers
+    mLabel:$('#marker-label'), mType:$('#marker-type'), mTime:$('#marker-time'),
+    addAtCur:$('#marker-add-cur'), addManual:$('#marker-add-manual'), clearMarkers:$('#marker-clear'), alignMarkers:$('#marker-align'),
+    // lane settings
+    lanesBox:$('#lanes-box'),
+    // overview
+    fCat:$('#filter-cat'), fText:$('#filter-text'),
+    ovPrev:$('#ov-prev'), ovNext:$('#ov-next'), ovPage:$('#ov-page'), ovGrid:$('#ov-grid'),
+    // export
+    pdfLayout:$('#pdf-layout'), pdfOrientation:$('#pdf-orientation'), pdfTitle:$('#pdf-title'),
+    exportPdf:$('#btn-export-pdf'), exportJson:$('#btn-export-json'), exportZip:$('#btn-export-zip'), exportJsonTop:$('#btn-export-json-top'),
+    pdfCover:$('#pdf-cover'), pdfLogo:$('#pdf-logo'), pdfGroup:$('#pdf-group'),
+    // files + toast
+    importJsonBtn:$('#btn-import-json'), importJsonFile:$('#file-import-json'),
+    importImages:$('#btn-import-images'), fileImages:$('#file-import-images'),
+    fileHidden:$('#file-hidden'), toast:$('#toast'),
+    thumbNav:$('#thumb-nav'),
+  };
+
+  function toast(msg){ el.toast.textContent=msg; el.toast.classList.add('show'); setTimeout(()=>el.toast.classList.remove('show'),2200); }
+
+  /** IDB */
+  function openDB(){
+    return new Promise((resolve)=>{
+      try{
+        const req=indexedDB.open('StoryboardApp',8);
+        req.onupgradeneeded=()=>{ const db=req.result; if(!db.objectStoreNames.contains('images')) db.createObjectStore('images'); };
+        req.onsuccess=()=>{ resolve(req.result); };
+        req.onerror=()=>resolve(null);
+      }catch(_){ resolve(null); }
+    });
+  }
+  function putImage(key, blob){ return new Promise((res,rej)=>{ if(!idb) return res(false); const tx=idb.transaction('images','readwrite'); tx.objectStore('images').put(blob,key); tx.oncomplete=()=>res(true); tx.onerror=()=>rej(tx.error); }); }
+  function getImage(key){ return new Promise((res,rej)=>{ if(!idb) return res(null); const tx=idb.transaction('images','readonly'); const rq=tx.objectStore('images').get(key); rq.onsuccess=()=>res(rq.result||null); rq.onerror=()=>rej(rq.error); }); }
+
+  /** Storage */
+  function save(){ localStorage.setItem(STORAGE_KEY, JSON.stringify(scenes)); el.projCount.textContent=String(scenes.length); }
+  function load(){ try{return JSON.parse(localStorage.getItem(STORAGE_KEY))||[]}catch(e){return[]} }
+  function saveMarkers(){ localStorage.setItem(MARKERS_KEY, JSON.stringify(markers)); }
+  function loadMarkers(){ try{return JSON.parse(localStorage.getItem(MARKERS_KEY))||[]}catch(e){return[]} }
+  function saveLanes(){ localStorage.setItem(LANE_KEY, JSON.stringify(laneMeta)); }
+  function loadLanes(){ try{return JSON.parse(localStorage.getItem(LANE_KEY))||[]}catch(e){return[]} }
+  function uid(){ return 'scene-' + Date.now() + '-' + Math.random().toString(36).slice(2,7); }
+
+  /** Utils */
+  function parseSec(v){
+    if(!v) return 5;
+    v=String(v).trim().toLowerCase();
+    if(/^\d+ms$/.test(v)) return Math.max(0.1, parseInt(v)/1000);
+    if(/^\d+(\.\d+)?m$/.test(v)) return Math.max(0.1, parseFloat(v)*60);
+    if(/^\d+s$/.test(v)) return Math.max(0.1, parseInt(v));
+    if(/^\d+:\d{1,2}$/.test(v)){ const [m,s]=v.split(':').map(Number); return Math.max(0.1, m*60+s); }
+    if(/^\d+(\.\d+)?$/.test(v)) return Math.max(0.1, parseFloat(v));
+    return 5;
+  }
+  function fmtTime(s){ const m=Math.floor(s/60),sec=Math.floor(s%60); return `${m}:${(sec<10?'0':'')+sec}`; }
+  // HTML escape helper to prevent injection in template strings.
+  function esc(s){
+    return String(s || '').replace(/[&<>"']/g, function(m){
+      return {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+      }[m];
+    });
+  }
+
+  /** Duration cache */
+  function durSec(s){ 
+    if(typeof s._durSec==='number') return s._durSec;
+    const d=parseSec(s.duration||'0'); s._durSec=d; return d;
+  }
+  function setDuration(s, value){
+    s.duration = value;
+    s._durSec = parseSec(value||'0');
+  }
+
+  /** Selection */
+  function isSelected(id){ return selected.has(id); }
+  function setSelected(id, on){ if(on) selected.add(id); else selected.delete(id); updateSelBar(); }
+  function updateSelBar(){ el.selCount.textContent=String(selected.size); }
+
+  /** Defaults */
+  function ensureDefaults(){
+    let t=0;
+    for(const s of scenes){
+      if(typeof s.startOffset!=='number' || isNaN(s.startOffset)){ s.startOffset=t; }
+      if(typeof s.lane!=='number' || isNaN(s.lane)){ s.lane=0; }
+      s._durSec=parseSec(s.duration||'0');
+      t += s._durSec;
+    }
+    if(!Array.isArray(laneMeta) || laneMeta.length<laneCount){
+      const lm=[];
+      const defs=[{n:'A-roll',c:'#7c3aed'},{n:'B-roll',c:'#3b82f6'},{n:'VFX',c:'#f59e0b'}];
+      for(let i=0;i<laneCount;i++){ lm.push(laneMeta[i]||{name:defs[i]?.n||('Spår '+i), color:defs[i]?.c||'#8899aa'}); }
+      laneMeta=lm;
+    }
+  }
+  function renumberByTime(){
+    scenes.sort((a,b)=> (a.lane-b.lane) || (a.startOffset-b.startOffset) || (a.title||'').localeCompare(b.title||''));
+    scenes.forEach((s,i)=> s.scene_number=i+1);
+  }
+
+  /** Quantize / Snap */
+  function beatLen(){ return beatMs/1000; }
+  function quantize(time, mode, dir){ // mode: 'beat' or 'marker', dir: -1 prev, 0 nearest, +1 next
+    if(mode==='marker'){
+      if(markers.length===0) return time;
+      const _ms=markersSorted();
+      if(dir<0){ // prev
+        let prev=_ms[0].t;
+        for(const m of _ms){ if(m.t<=time) prev=m.t; else break; }
+        return prev;
+      }else if(dir>0){ // next
+        for(const m of _ms){ if(m.t>=time) return m.t; }
+        return _ms[_ms.length-1].t;
+      }else{ // nearest
+        let best=_ms[0].t, d=1e9;
+        for(const m of _ms){ const dd=Math.abs(time-m.t); if(dd<d){d=dd; best=m.t;} }
+        return best;
+      }
+    } else {
+      const step=beatLen()*quantDiv;
+      if(dir<0) return Math.floor(time/step)*step;
+      if(dir>0) return Math.ceil(time/step)*step;
+      return Math.round(time/step)*step;
+    }
+  }
+
+  /** Overlaps */
+  function laneScenes(ln){ return scenes.filter(s=> (s.lane||0)===ln).sort((a,b)=>a.startOffset-b.startOffset); }
+  function findOverlaps(){
+    const set=new Set();
+    for(let ln=0; ln<laneCount; ln++){
+      const arr=laneScenes(ln);
+      for(let i=0;i<arr.length-1;i++){
+        const a=arr[i], b=arr[i+1];
+        if(a.startOffset+durSec(a) > b.startOffset) { set.add(a.id); set.add(b.id); }
+      }
+    }
+    return set;
+  }
+  function resolveOverlaps(){
+    let fixes=0;
+    for(let ln=0; ln<laneCount; ln++){
+      const arr=laneScenes(ln);
+      for(let i=0;i<arr.length-1;i++){
+        const a=arr[i], b=arr[i+1];
+        const aEnd=a.startOffset+durSec(a)+0.001;
+        if(aEnd > b.startOffset && !b.locked){
+          const snapped=quantize(aEnd, hardGrid?'beat':snapMode, +1); // push forward
+          b.startOffset = snapped;
+          b.updated_at=new Date().toISOString();
+          fixes++;
+        }
+      }
+    }
+    if(fixes){ renumberByTime(); saveDebounced(); scheduleRender({timeline:true, scenes:true}); toast(`Överlapp auto-fixade: ${fixes}`); } else toast('Inga överlapp att fixa');
+  }
+  function reflowLane(ln){
+    const arr=laneScenes(ln);
+    for(let i=0;i<arr.length;i++){
+      const prev=arr[i-1];
+      if(prev){
+        const minStart=prev.startOffset+durSec(prev)+0.001;
+        if(arr[i].startOffset < minStart && !arr[i].locked){
+          let t=minStart;
+          if(hardGrid) t=quantize(t,'beat',+1);
+          arr[i].startOffset = t;
+          arr[i].updated_at=new Date().toISOString();
+        }
+      }
+    }
+  }
+
+  /** Scenes CRUD */
+  function addScene(){
+    const last=scenes[scenes.length-1];
+    const newStart= last ? (last.startOffset+durSec(last)) : 0;
+    scenes.push({
+      id:uid(), scene_number:(scenes[scenes.length-1]?.scene_number||0)+1,
+      title:'', description:'', duration:'5s', camera_angle:'Medium', notes:'',
+      tags:{camera:[],light:[],vfx:[]}, image_key:'', thumbnail:'', thumbnail_webp:'',
+      startOffset:newStart, lane:0, locked:false,
+      created_at:new Date().toISOString(), updated_at:new Date().toISOString(), _durSec:5
+    });
+    if(autoReflow) reflowLane(0);
+    saveDebounced(); scheduleRender({scenes:true, timeline:true, overview:true}); toast('Scen tillagd');
+  }
+  function duplicateScene(s){
+    const c=JSON.parse(JSON.stringify(s)); c.id=uid(); c.created_at=new Date().toISOString(); c.updated_at=c.created_at;
+    c.startOffset = s.startOffset + durSec(s) + 0.001;
+    scenes.push(c);
+    if(autoReflow) reflowLane(c.lane||0);
+    renumberByTime(); saveDebounced(); scheduleRender({scenes:true, timeline:true, overview:true}); toast('Scen duplicerad');
+  }
+  function deleteScene(s){
+    if(!confirm('Ta bort scen?')) return;
+    const ln=s.lane||0;
+    scenes=scenes.filter(x=>x.id!==s.id);
+    if(autoReflow) reflowLane(ln);
+    renumberByTime(); saveDebounced(); scheduleRender({scenes:true, timeline:true, overview:true}); toast('Scen borttagen');
+  }
+
+  /** Bulk */
+  function ensureSelection(){ if(selected.size===0){ alert('Markera minst en scen.'); return false; } return true; }
+  function bulkSetDuration(){ if(!ensureSelection()) return; const val=(el.bulkDur.value||'').trim(); if(!val) return alert('Ange längd.');
+    const lanesChanged=new Set();
+    for(const id of selected){ const s=scenes.find(x=>x.id===id); if(s && !s.locked){ setDuration(s, val); s.updated_at=new Date().toISOString(); lanesChanged.add(s.lane||0); } }
+    saveDebounced(); if(autoReflow) lanesChanged.forEach(reflowLane); renumberByTime(); scheduleRender({scenes:true, timeline:true}); toast('Längd uppdaterad');
+  }
+  function bulkSetCamera(){ if(!ensureSelection()) return; const cam=el.bulkCam.value;
+    for(const id of selected){ const s=scenes.find(x=>x.id===id); if(s && !s.locked){ s.camera_angle=cam; s.updated_at=new Date().toISOString(); } }
+    saveDebounced(); scheduleRender({scenes:true}); toast('Kamera uppdaterad');
+  }
+  function parseTagsInput(str){ return String(str||'').split(',').map(x=>x.trim()).filter(Boolean); }
+  function applyTags(mode){
+    if(!ensureSelection()) return;
+    const cam=parseTagsInput(el.bulkCamTags.value), lig=parseTagsInput(el.bulkLightTags.value), vfx=parseTagsInput(el.bulkVfxTags.value);
+    for(const id of selected){
+      const s=scenes.find(x=>x.id===id); if(!s || s.locked) continue; s.tags=s.tags||{camera:[],light:[],vfx:[]};
+      for(const [cat, incoming] of [['camera',cam],['light',lig],['vfx',vfx]]){
+        if(mode==='add') s.tags[cat]=Array.from(new Set([...(s.tags[cat]||[]),...incoming]));
+        else if(mode==='replace') s.tags[cat]=incoming;
+        else if(mode==='clear') s.tags[cat]=incoming.length? (s.tags[cat]||[]).filter(t=>!incoming.includes(t)) : [];
+      }
+      s.updated_at=new Date().toISOString();
+    }
+    saveDebounced(); scheduleRender({scenes:true, overview:true}); toast(mode==='add'?'Taggar tillagda':(mode==='replace'?'Taggar ersatta':'Taggar rensade'));
+  }
+  function bulkDuplicate(){ if(!ensureSelection()) return; const ids=[...selected]; for(const id of ids){ const s=scenes.find(x=>x.id===id); if(s) duplicateScene(s); } selected.clear(); saveDebounced(); renumberByTime(); scheduleRender({scenes:true, timeline:true}); toast('Markerade duplicerade'); }
+  function bulkDelete(){ if(!ensureSelection()) return; if(!confirm('Ta bort markerade scener?')) return;
+    const lanesChanged=new Set();
+    scenes = scenes.filter(s=> { if(selected.has(s.id) && !s.locked){ lanesChanged.add(s.lane||0); return false;} return true; });
+    selected.clear(); if(autoReflow) lanesChanged.forEach(reflowLane); renumberByTime(); saveDebounced(); scheduleRender({scenes:true, timeline:true, overview:true}); toast('Markerade borttagna');
+  }
+  function bulkSetLane(){ if(!ensureSelection()) return; const ln=Number(el.bulkLane.value||0);
+    for(const id of selected){ const s=scenes.find(x=>x.id===id); if(s && !s.locked){ s.lane=ln; s.updated_at=new Date().toISOString(); } }
+    saveDebounced(); if(autoReflow) reflowLane(ln); renumberByTime(); scheduleRender({scenes:true, timeline:true}); toast('Lane satt');
+  }
+  function bulkLockScenes(flag){ if(!ensureSelection()) return; for(const id of selected){ const s=scenes.find(x=>x.id===id); if(s){ s.locked=!!flag; s.updated_at=new Date().toISOString(); } } saveDebounced(); scheduleRender({scenes:true, timeline:true}); toast(flag?'Låsta':'Upplåsta'); }
+
+  /** Images & Video */
+  // Put image or route to video handler
+  async function putPhotoForScene(s,file){
+    if(file && file.type && file.type.startsWith('video/')){
+      // Delegate to video handler
+      return putVideoForScene(s,file);
+    }
+    // original image logic
+    const key='img-'+s.id;
+    await putImage(key,file);
+    s.image_key=key;
+    const {jpeg, webp}=await generateThumb(file,240,135);
+    s.thumbnail=jpeg;
+    s.thumbnail_webp=webp;
+    s.media_type = 'image';
+    s.updated_at=new Date().toISOString();
+    saveDebounced();
+  }
+  // Generate a thumbnail for an image file
+  async function generateThumb(file,w=240,h=135){
+    const url=URL.createObjectURL(file);
+    const img=new Image();
+    await new Promise((res,rej)=>{ img.onload=()=>res(); img.onerror=rej; img.src=url; });
+    const c=document.createElement('canvas'); c.width=w; c.height=h;
+    const ctx=c.getContext('2d');
+    ctx.fillStyle='#0d1319';
+    ctx.fillRect(0,0,w,h);
+    const r=Math.min(w/img.naturalWidth, h/img.naturalHeight);
+    const iw=img.naturalWidth*r, ih=img.naturalHeight*r;
+    ctx.drawImage(img,(w-iw)/2,(h-ih)/2,iw,ih);
+    URL.revokeObjectURL(url);
+    // JPEG
+    const jpeg=c.toDataURL('image/jpeg',0.82);
+    // Attempt WebP if supported
+    let webp='';
+    try{
+      const webpTest=c.toDataURL('image/webp',0.8);
+      if(webpTest.startsWith('data:image/webp')){
+        webp=webpTest;
+      }
+    }catch(e){ webp=''; }
+    return {jpeg, webp};
+  }
+  // Capture a poster frame from a video and return jpeg/webp thumbnails
+  async function captureVideoThumb(file, w=240, h=135, seekSec=1){
+    const url = URL.createObjectURL(file);
+    try{
+      const v = document.createElement('video');
+      v.preload = 'metadata';
+      v.muted = true;
+      v.src = url;
+      await new Promise((res, rej) => {
+        v.onloadedmetadata = () => res();
+        v.onerror = () => rej(new Error('Metadata load fail'));
+      });
+      const t = Math.min(
+        isFinite(v.duration) && v.duration > 0 ? Math.max(0.1, Math.min(seekSec, v.duration * 0.2)) : 0.5,
+        10
+      );
+      await new Promise((res, rej) => {
+        const onseeked = () => { v.removeEventListener('seeked', onseeked); res(); };
+        v.addEventListener('seeked', onseeked);
+        try{ v.currentTime = t; } catch(e){ rej(e); }
+      });
+      const c = document.createElement('canvas'); c.width = w; c.height = h;
+      const ctx = c.getContext('2d');
+      ctx.fillStyle = '#0d1319';
+      ctx.fillRect(0,0,w,h);
+      const vw = v.videoWidth || w, vh = v.videoHeight || h;
+      const r = Math.min(w/vw, h/vh);
+      const dw = vw * r, dh = vh * r;
+      ctx.drawImage(v, (w - dw) / 2, (h - dh) / 2, dw, dh);
+      const jpeg = c.toDataURL('image/jpeg', 0.82);
+      let webp = '';
+      try{
+        const webpTest = c.toDataURL('image/webp', 0.8);
+        if(webpTest.startsWith('data:image/webp')) webp = webpTest;
+      }catch(_){ webp = ''; }
+      return { jpeg, webp };
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }
+  // Store a video and generate its thumbnail
+  async function putVideoForScene(s, file){
+    const key = 'vid-' + s.id;
+    await putImage(key, file);
+    s.video_key = key;
+    s.media_type = 'video';
+    const {jpeg, webp} = await captureVideoThumb(file, 240, 135, 1);
+    s.thumbnail = jpeg;
+    s.thumbnail_webp = webp;
+    s.updated_at = new Date().toISOString();
+    saveDebounced();
+  }
+
+  /**
+   * Open a modal dialog to preview a stored video.
+   * This function lazily creates the dialog element on first invocation and reuses it for subsequent views.
+   * @param {Object} s - The scene object containing a video_key
+   */
+  async function openVideoPreview(s){
+    if(!s || !s.video_key) return;
+    const blob = await getImage(s.video_key);
+    if(!blob){ alert('Kunde inte läsa videon.'); return; }
+    const url = URL.createObjectURL(blob);
+    let dlg = document.querySelector('#video-dialog');
+    if(!dlg){
+      dlg = document.createElement('dialog');
+      dlg.id = 'video-dialog';
+      dlg.innerHTML = `\
+        <style>\
+          #video-dialog::backdrop{ background:rgba(0,0,0,.6); }\
+          #video-dialog{ padding:0; border:none; border-radius:12px; overflow:hidden; max-width:90vw; }\
+          #video-dialog header{ display:flex; align-items:center; justify-content:space-between; padding:.5rem .75rem; background:#0b0f14; color:#cfe3ff; }\
+          #video-dialog .body{ background:#0f141a; padding:.5rem; }\
+          #video-dialog video{ max-width:86vw; max-height:70vh; display:block; }\
+        </style>\
+        <header><strong>Videoförhandsvisning</strong><button id="dlg-close" class="btn ghost">Stäng</button></header>\
+        <div class="body"><video id="dlg-video" controls playsinline></video></div>`;
+      document.body.appendChild(dlg);
+      dlg.querySelector('#dlg-close').onclick = () => dlg.close();
+      dlg.addEventListener('close', () => {
+        try{
+          const v = dlg.querySelector('#dlg-video');
+          v.pause();
+          v.removeAttribute('src');
+          v.load();
+        }catch(_){ /* ignore */ }
+      });
+    }
+    const v = dlg.querySelector('#dlg-video');
+    v.src = url;
+    try{ v.play(); }catch(_){ /* ignore */ }
+    dlg.showModal();
+    v.onloadeddata = () => setTimeout(() => URL.revokeObjectURL(url), 2000);
+  }
+  // Batch import images or videos
+  function batchImportImages(files){
+    let i=0;
+    const next=async()=>{
+      if(i>=files.length){ scheduleRender({scenes:true, overview:true, timeline:true}); toast('Batch-import klar'); return; }
+      const f=files[i++];
+      const s=scenes.find(x=>(!x.image_key && !x.video_key))||scenes[scenes.length-1];
+      await putPhotoForScene(s,f);
+      next();
+    };
+    next();
+  }
+
+  /** Nearest marker label <= time */
+  function sectionLabelAt(time){
+    if(markers.length===0) return '';
+    const _ms=markersSorted();
+    let lab=''; for(const m of _ms){ if(m.t<=time) lab=m.label||m.type||''; else break; }
+    return lab;
+  }
+
+  /** Timeline rendering */
+  function renderTimeline(){
+    el.tl.innerHTML='';
+    const totalSec = Math.max(60, ...scenes.map(s=> (s.startOffset||0)+durSec(s)));
+    const beats=Math.ceil((totalSec*1000)/beatMs)+4;
+    for(let i=0;i<=beats;i++){ const x=Math.round((i*beatMs/1000)*timelinePxPerSec);
+      const b=document.createElement('div'); b.className='beat'; b.style.left=x+'px'; el.tl.appendChild(b);
+    }
+    // lanes
+    const laneHeight=86, laneGap=16;
+    const tlHeight=24 + laneCount*(laneHeight+laneGap);
+    el.tl.style.height=(tlHeight+20)+'px';
+    for(let ln=0; ln<laneCount; ln++){
+      const y=30 + ln*(laneHeight+laneGap);
+      const line=document.createElement('div'); line.className='lane-line'; line.style.top=(y-6)+'px'; line.style.background=laneMeta[ln]?.color||'#2a3440'; line.style.opacity='0.35'; el.tl.appendChild(line);
+      const lab=document.createElement('div'); lab.className='lane-label'; lab.style.top=(y-18)+'px'; lab.textContent=(laneMeta[ln]?.name||('Spår '+ln)); lab.style.color=laneMeta[ln]?.color||'#7d8a97'; el.tl.appendChild(lab);
+    }
+    // markers
+    const _ms=markersSorted();
+    for(const m of _ms){ const x=Math.round(m.t*timelinePxPerSec);
+      const mk=document.createElement('div'); mk.className='marker'; mk.style.left=x+'px'; mk.dataset.label=m.label||m.type||'Marker'; el.tl.appendChild(mk);
+    }
+    snapEl=document.createElement('div'); snapEl.className='snap'; snapEl.style.display='none'; el.tl.appendChild(snapEl);
+
+    const overlaps=findOverlaps();
+    for(const s of scenes){
+      const start=(typeof s.startOffset==='number')?s.startOffset:0;
+      const sec=durSec(s)||5; const w=Math.max(80, Math.round(sec*timelinePxPerSec));
+      const ln=Math.max(0, Math.min(laneCount-1, Number(s.lane||0)));
+      const laneY=30 + ln*(laneHeight+laneGap);
+      const block=document.createElement('div'); block.className='block'; block.dataset.id=s.id;
+      if(overlaps.has(s.id)) block.classList.add('overlap');
+      if(s.locked) block.classList.add('locked');
+      block.style.left=Math.round(start*timelinePxPerSec)+'px'; block.style.top=laneY+'px'; block.style.width=w+'px';
+      block.style.borderColor=laneMeta[ln]?.color||'#445';
+      block.innerHTML=`<div class="title">${esc(s.title||'Scen')}</div><div class="dur">${sec.toFixed(2)}s @ ${fmtTime(start)} — ${(laneMeta[ln]?.name||('L'+ln))}</div>`;
+      makeBlockDraggable(block, s);
+      el.tl.appendChild(block);
+    }
+    const o=findOverlaps(); if(o.size>0) toast(`Varning: överlapp (${o.size})`);
+  }
+  function makeBlockDraggable(block, s){
+    if(s.locked) return;
+    let startX=0, origLeft=0;
+    function onDown(ev){
+      if(s.locked) return;
+      ev.preventDefault();
+      block.classList.add('drag');
+      startX=(ev.touches?ev.touches[0].clientX:ev.clientX);
+      const rect=block.getBoundingClientRect(); const tlRect=el.tl.getBoundingClientRect();
+      origLeft=rect.left - tlRect.left + el.tl.scrollLeft;
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('touchmove', onMove, {passive:false});
+      document.addEventListener('mouseup', onUp, {once:true});
+      document.addEventListener('touchend', onUp, {once:true});
+    }
+    function onMove(ev){
+      ev.preventDefault();
+      const x=(ev.touches?ev.touches[0].clientX:ev.clientX);
+      const dx=x-startX;
+      const newLeft=Math.max(0, origLeft+dx);
+      const rawTime=newLeft/timelinePxPerSec;
+      const useMarkers=(ev.shiftKey || snapMode==='marker');
+      const dir = ev.ctrlKey ? +1 : (ev.altKey ? -1 : 0);
+      const snapTime=quantize(rawTime, useMarkers?'marker':'beat', dir);
+      const snapX=Math.round(snapTime*timelinePxPerSec) - el.tl.scrollLeft;
+      snapEl.style.left=snapX+'px'; snapEl.style.display='block';
+      block.style.left=Math.round(newLeft - el.tl.scrollLeft)+'px';
+      block.querySelector('.dur').textContent = `${durSec(s).toFixed(2)}s @ ${fmtTime(snapTime)} — ${(laneMeta[s.lane||0]?.name||('L'+(s.lane||0)))}`;
+      block.dataset._tempTime = snapTime;
+    }
+  function onUp(){
+    block.classList.remove('drag'); snapEl.style.display='none';
+    // Clean up move listeners to restore normal scroll behaviour
+    document.removeEventListener('mousemove', onMove);
+    document.removeEventListener('touchmove', onMove);
+    let t = Number(block.dataset._tempTime||0);
+    if(hardGrid) t = quantize(t, 'beat', 0);
+    s.startOffset=Math.max(0,t);
+    s.updated_at=new Date().toISOString();
+    if(autoReflow) reflowLane(s.lane||0);
+    renumberByTime(); saveDebounced(); scheduleRender({timeline:true, scenes:true});
+  }
+    block.addEventListener('mousedown', onDown);
+    block.addEventListener('touchstart', onDown, {passive:false});
+  }
+
+  /** Markers */
+  function addMarkerAt(time, label, type){ markers.push({t:Math.max(0,Number(time)||0), label:label||type||'Marker', type:type||'Section'}); markDirty(); saveMarkers(); scheduleRender({timeline:true}); toast('Marker tillagd'); }
+  function parseTimeStr(str){ str=String(str||'').trim(); if(/^\d+:\d{1,2}$/.test(str)){ const [m,s]=str.split(':').map(Number); return m*60+s; } if(/^\d+(\.\d+)?$/.test(str)) return Number(str); return null; }
+  function alignScenesToMarkers(){
+    if(markers.length<2 || scenes.length===0) { toast('Behöver minst 2 markers'); return; }
+    const _ms=markersSorted();
+    for(let i=0;i<_ms.length-1 && i<scenes.length;i++){
+      const a=_ms[i].t, b=_ms[i+1].t;
+      const dur=Math.max(0.2, b-a);
+      const s=scenes[i]; if(s && !s.locked){ setDuration(s, (hardGrid ? (Math.round(dur/beatLen())*beatLen()) : dur).toFixed(2)+'s'); s.startOffset=hardGrid?quantize(a,'beat',0):a; }
+    }
+    if(autoReflow) for(let ln=0; ln<laneCount; ln++) reflowLane(ln);
+    renumberByTime(); saveDebounced(); scheduleRender({timeline:true, scenes:true}); toast('Scener justerade till markers');
+  }
+
+  /** Scenes View */
+  function scenesForView(){
+    const arr=[...scenes];
+    if(viewSortBy==='start'){ arr.sort((a,b)=> (a.startOffset-b.startOffset) || (a.title||'').localeCompare(b.title||'')); }
+    if(viewSortBy==='title'){ arr.sort((a,b)=> (a.title||'').localeCompare(b.title||'')); }
+    if(viewSortBy==='duration'){ arr.sort((a,b)=> durSec(a)-durSec(b)); }
+    if(viewSortBy==='camera'){ arr.sort((a,b)=> (a.camera_angle||'').localeCompare(b.camera_angle||'')); }
+    if(viewSortDir==='desc') arr.reverse();
+    return arr;
+  }
+  function renderScenes(){
+    el.grid.innerHTML='';
+    if(!scenes.length){ el.empty.style.display=''; updateSelBar(); return; } else el.empty.style.display='none';
+    const frag=document.createDocumentFragment();
+    const list=scenesForView();
+    for(const s of list){
+      const card=document.createElement('div'); card.className='card'; card.dataset.id=s.id;
+      if(isSelected(s.id)) card.classList.add('selected');
+      if(s.locked) card.classList.add('locked');
+      const ln = s.lane||0; const lname = laneMeta[ln]?.name || ('Spår '+ln);
+      card.innerHTML=`
+        <header>
+          <div class="left">
+            <input type="checkbox" class="sel" ${isSelected(s.id)?'checked':''} title="Markera scenen">
+            <span class="num">Scen #${s.scene_number} — t=${fmtTime(s.startOffset||0)} — ${lname}</span>
+          </div>
+          <div class="actions">
+            <button class="icon" data-act="lock" title="${s.locked?'Lås upp':'Lås'}" aria-label="${s.locked?'Lås upp scen':'Lås scen'}">${s.locked?'🔓':'🔒'}</button>
+            <button class="icon" data-act="dup" title="Duplicera" aria-label="Duplicera scen">📋</button>
+            <button class="icon" data-act="del" title="Ta bort" aria-label="Ta bort scen">🗑️</button>
+          </div>
+        </header>
+        <div class="img"><div class="placeholder">🖼️</div><img loading="lazy" decoding="async" alt=""></div>
+        <div class="body">
+          <div><label>Titel</label><input data-k="title" type="text" value="${esc(s.title)}" ${s.locked?'disabled':''}></div>
+          <div><label>Beskrivning</label><textarea data-k="description" ${s.locked?'disabled':''}>${esc(s.description)}</textarea></div>
+          <div style="display:flex;gap:8px">
+            <div style="flex:1"><label>Längd</label><input data-k="duration" type="text" value="${esc(s.duration)}" ${s.locked?'disabled':''} placeholder="1:30 / 12s / 1.5m"></div>
+            <div style="flex:1"><label>Kamera</label>
+              <select data-k="camera_angle" ${s.locked?'disabled':''}>
+                ${['Wide','Medium','Close','Dutch','Top','Low'].map(v=>`<option ${v===(s.camera_angle||'')?'selected':''}>${v}</option>`).join('')}
+              </select>
+            </div>
+          </div>
+          <div style="display:flex;gap:8px">
+            <div style="flex:1"><label>Spår (lane)</label>
+              <select data-k="lane" ${s.locked?'disabled':''}>
+                ${[0,1,2].map(v=>`<option value="${v}" ${v===(s.lane||0)?'selected':''}>${laneMeta[v]?.name||('Spår '+v)}</option>`).join('')}
+              </select>
+            </div>
+            <div style="flex:1"><label>Start (sek)</label><input data-k="startOffset" type="number" min="0" step="0.01" value="${Number(s.startOffset||0).toFixed(2)}" ${s.locked?'disabled':''}></div>
+          </div>
+          <div><label>Anteckningar</label><textarea data-k="notes" ${s.locked?'disabled':''}>${esc(s.notes)}</textarea></div>
+          <div>
+            <label>Taggar</label>
+            <div class="chips">
+              ${['camera','light','vfx'].map(cat=>`<span class="chip">${cat}: <input data-tag="${cat}" type="text" ${s.locked?'disabled':''} placeholder="kommaseparerat" value="${esc((s.tags?.[cat]||[]).join(', '))}" style="min-width:140px"></span>`).join('')}
+            </div>
+            <div class="qtags">
+              <span class="badge">Presets:</span>
+              <button class="qt" data-cat="camera" data-val="low angle">camera: low angle</button>
+              <button class="qt" data-cat="camera" data-val="handheld">camera: handheld</button>
+              <button class="qt" data-cat="light" data-val="backlight">light: backlight</button>
+              <button class="qt" data-cat="light" data-val="smoke">light: smoke</button>
+              <button class="qt" data-cat="vfx" data-val="smoke">vfx: smoke</button>
+              <button class="qt" data-cat="vfx" data-val="sparks">vfx: sparks</button>
+              <button class="qt" data-cat="vfx" data-val="particles">vfx: particles</button>
+              <button class="qt" data-cat="vfx" data-val="laser">vfx: laser</button>
+            </div>
+          </div>
+          <div class="toolbar">
+            <button class="btn" data-act="photo" ${s.locked?'disabled':''} aria-label="Ladda media">
+              <span class="material-icons">photo_camera</span> Ladda media
+            </button>
+            <button class="btn" data-act="clearphoto" ${s.locked?'disabled':''} aria-label="Rensa media">
+              <span class="material-icons">clear</span> Rensa media
+            </button>
+          </div>
+        </div>`;
+      const img=card.querySelector('img'); const ph=card.querySelector('.placeholder');
+      if(s.image_key){ getImage(s.image_key).then(blob=>{ if(blob){ const url=URL.createObjectURL(blob); // choose webp if stored
+          const srcData=(s.thumbnail_webp && s.thumbnail_webp.startsWith('data:image/webp'))? s.thumbnail_webp : s.thumbnail;
+          // Use srcData for src; fallback to blob if missing
+          if(srcData){ img.src=srcData; } else { img.src=url; }
+          img.alt = s.title ? `Bild för scen ${s.title}` : 'Bild för scen';
+          img.style.display='block'; ph.style.display='none'; img.onload=()=>{ if(url.startsWith('blob:')) URL.revokeObjectURL(url); };
+        } });
+      } else if(s.thumbnail){
+        img.src=s.thumbnail;
+        img.alt = s.title ? `Bild för scen ${s.title}` : 'Bild för scen';
+        img.style.display='block'; ph.style.display='none';
+      }
+      // collapse cards by default to reduce vertical footprint
+      card.classList.add('collapsed');
+      // toggle collapse when clicking header (but ignore button clicks inside header)
+      card.querySelector('header').addEventListener('click', (ev) => {
+        // if user clicked a button or checkbox inside header, ignore collapse toggle
+        if(ev.target.closest('button') || ev.target.closest('input')) return;
+        card.classList.toggle('collapsed');
+      });
+      // inline
+      card.addEventListener('input', ev=>{
+        if(s.locked) return;
+        const t=ev.target; const k=t.getAttribute('data-k');
+        if(k){
+          if(k==='lane'){ const old=s.lane||0; s.lane=Number(t.value)||0; if(autoReflow){ reflowLane(old); reflowLane(s.lane); } scheduleRender({timeline:true}); }
+          else if(k==='startOffset'){ let val=Math.max(0, Number(t.value)||0); if(hardGrid) val=quantize(val,'beat',0); s.startOffset=val; if(autoReflow) reflowLane(s.lane||0); scheduleRender({timeline:true}); }
+          else if(k==='duration'){ setDuration(s, t.value); if(autoReflow) reflowLane(s.lane||0); scheduleRender({timeline:true}); }
+          else { s[k]=t.value; }
+          s.updated_at=new Date().toISOString(); saveDebounced(); return;
+        }
+        const tag=t.getAttribute('data-tag'); if(tag){ s.tags=s.tags||{}; s.tags[tag]=t.value.split(',').map(x=>x.trim()).filter(Boolean); saveDebounced(); }
+      });
+      // actions
+      card.querySelector('[data-act="dup"]').onclick=()=>duplicateScene(s);
+      card.querySelector('[data-act="del"]').onclick=()=>deleteScene(s);
+      card.querySelector('[data-act="lock"]').onclick=()=>{ s.locked=!s.locked; saveDebounced(); scheduleRender({scenes:true, timeline:true}); };
+      card.querySelector('[data-act="photo"]').onclick=()=>{ el.fileHidden.onchange=async e=>{ const f=e.target.files[0]; if(f){ await putPhotoForScene(s,f); scheduleRender({scenes:true, timeline:true, overview:true}); } el.fileHidden.value=''; }; el.fileHidden.click(); };
+      card.querySelector('[data-act="clearphoto"]').onclick=()=>{
+        // Clear both image and video data
+        s.image_key='';
+        s.video_key='';
+        s.media_type='';
+        s.thumbnail='';
+        s.thumbnail_webp='';
+        saveDebounced();
+        scheduleRender({scenes:true, timeline:true, overview:true});
+      };
+      // If the scene contains a video, add a play button to the toolbar
+      if(s.video_key){
+        const tb = card.querySelector('.toolbar');
+        if(tb){
+          const playBtn = document.createElement('button');
+          playBtn.className = 'btn';
+          playBtn.setAttribute('aria-label','Spela upp video');
+          playBtn.innerHTML = '<span class="material-icons">play_circle</span> Spela video';
+          playBtn.onclick = () => openVideoPreview(s);
+          tb.appendChild(playBtn);
+        }
+      }
+      // selection
+      card.querySelector('.sel').onchange=(e)=>{ setSelected(s.id, e.target.checked); if(e.target.checked) card.classList.add('selected'); else card.classList.remove('selected'); };
+      // per-card quick presets
+      card.querySelectorAll('.qtags .qt').forEach(q=> q.addEventListener('click', ()=>{
+        if(s.locked) return;
+        const cat=q.dataset.cat, val=q.dataset.val;
+        s.tags=s.tags||{camera:[],light:[],vfx:[]}; const arr=s.tags[cat]||[]; if(!arr.includes(val)) arr.push(val); s.tags[cat]=arr;
+        s.updated_at=new Date().toISOString(); saveDebounced(); scheduleRender({scenes:true, overview:true}); toast(`Preset tillagd: ${cat} ${val}`);
+      }));
+      frag.appendChild(card);
+    }
+    el.grid.appendChild(frag);
+    el.projCount.textContent=String(scenes.length);
+    updateSelBar();
+  // reposition thumbnails after scene rendering
+  updateThumbNavPosition();
+
+    // Update side thumbnail navigation
+    if(el.thumbNav){
+      el.thumbNav.innerHTML='';
+      list.forEach(s=>{
+        const thumbImg=document.createElement('img');
+        // select image source: prefer webp, then jpeg, else fallback solid color svg
+        let srcData = '';
+        if(s.thumbnail_webp && s.thumbnail_webp.startsWith('data:image')) srcData = s.thumbnail_webp;
+        else if(s.thumbnail && s.thumbnail.startsWith('data:image')) srcData = s.thumbnail;
+        else {
+          // dark placeholder svg (16:9 aspect)
+          const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='60' height='34'><rect width='60' height='34' fill='%23232937' rx='4' ry='4'/></svg>`;
+          srcData = 'data:image/svg+xml;utf8,' + encodeURIComponent(svg);
+        }
+        thumbImg.src = srcData;
+        thumbImg.alt = s.title ? `Miniatyr ${s.title}` : 'Miniatyr';
+        thumbImg.dataset.id = s.id;
+        thumbImg.addEventListener('click', () => {
+          const cardEl = el.grid.querySelector(`[data-id='${s.id}']`);
+          if(cardEl) cardEl.scrollIntoView({behavior:'smooth', block:'center'});
+        });
+        el.thumbNav.appendChild(thumbImg);
+      });
+    }
+  }
+
+  /** Overview with lazy thumbs */
+  let ovPage=1;
+  let _ovObserver=null;
+  function ensureOvObserver(){
+    if(_ovObserver) return _ovObserver;
+    _ovObserver = new IntersectionObserver(async entries=>{
+      for(const e of entries){
+        if(e.isIntersecting){
+          const div=e.target; const sid=div.getAttribute('data-id');
+          const s=scenes.find(x=>x.id===sid); if(!s || !s.image_key) { _ovObserver.unobserve(div); continue; }
+          try{ const blob=await getImage(s.image_key); if(blob){ const url=URL.createObjectURL(blob); const srcData=(s.thumbnail_webp && s.thumbnail_webp.startsWith('data:image/webp'))? s.thumbnail_webp : s.thumbnail; if(srcData){ div.style.backgroundImage=`url('${srcData}')`; } else { div.style.backgroundImage=`url('${url}')`; setTimeout(()=>URL.revokeObjectURL(url),2000); }
+              div.textContent=''; } }
+          catch(_){}
+          _ovObserver.unobserve(div);
+        }
+      }
+    }, {root:el.ovGrid, rootMargin:'200px'});
+    return _ovObserver;
+  }
+  function matchesFilter(s){
+    const cat=el.fCat.value; const q=(el.fText.value||'').trim().toLowerCase();
+    if(!q) return true;
+    if(cat==='title') return (s.title||'').toLowerCase().includes(q);
+    if(cat==='description') return (s.description||'').toLowerCase().includes(q);
+    if(cat==='tags.camera') return (s.tags?.camera||[]).join(',').toLowerCase().includes(q);
+    if(cat==='tags.light') return (s.tags?.light||[]).join(',').toLowerCase().includes(q);
+    if(cat==='tags.vfx') return (s.tags?.vfx||[]).join(',').toLowerCase().includes(q);
+    return true;
+  }
+  function renderOverview(){
+    const per=6;
+    const filtered=scenes.filter(matchesFilter);
+    const pages=Math.max(1, Math.ceil(filtered.length/per));
+    ovPage=Math.max(1, Math.min(ovPage, pages));
+    el.ovPage.textContent=`${ovPage} / ${pages}`;
+    el.ovGrid.innerHTML='';
+    const start=(ovPage-1)*per;
+    const obs=ensureOvObserver();
+    filtered.slice(start, start+per).forEach(s=>{
+      const div=document.createElement('div'); div.className='thumb'; div.textContent='Ingen bild'; div.setAttribute('data-id', s.id);
+      el.ovGrid.appendChild(div);
+      if(s.image_key) obs.observe(div);
+    });
+  }
+
+/**
+ * Update the side thumbnail navigation's vertical position based on the header
+ * and whether bulk selection tools are visible. Keeps thumbnails from
+ * overlapping the top menu on mobile.
+ */
+function updateThumbNavPosition(){
+  if(!el.thumbNav) return;
+  // On narrow screens the thumbnail bar is positioned via CSS at the bottom.
+  if(window.innerWidth < 900){
+    el.thumbNav.style.top = 'auto';
+    return;
+  }
+  const headerRect = document.querySelector('header').getBoundingClientRect();
+  let offset = headerRect.height + 8;
+  // account for selbar if visible
+  if(!el.selbar.classList.contains('hidden')){
+    offset += el.selbar.offsetHeight + 8;
+  }
+  // account for actions menu if visible on small screens (when actions collapsed) – use 900px breakpoint
+  if(window.innerWidth < 900 && !el.actions.classList.contains('hidden')){
+    offset += el.actions.offsetHeight + 8;
+  }
+  el.thumbNav.style.top = offset + 'px';
+}
+
+  /** Audio */
+  async function onAudioFile(file){
+    try{
+      if(!audioCtx) audioCtx=new (window.AudioContext||window.webkitAudioContext)();
+      const arr=await file.arrayBuffer(); audioBuf=await audioCtx.decodeAudioData(arr);
+      el.durTime.textContent=fmtTime(audioBuf.duration); el.scrub.max=''+Math.floor(audioBuf.duration);
+      audioOffset=0; audioStart=0; toast('Audio inläst');
+    }catch(e){ alert('Kunde inte läsa ljudfilen.'); }
+  }
+  function playAudio(){ if(!audioCtx||!audioBuf) return; stopAudio(); audioSrc=audioCtx.createBufferSource(); audioSrc.buffer=audioBuf; audioSrc.connect(audioCtx.destination); audioStart=audioCtx.currentTime-audioOffset; audioSrc.start(0,audioOffset); tick(); }
+  function stopAudio(){ if(audioSrc){ try{audioSrc.stop()}catch(e){} audioSrc.disconnect(); audioSrc=null; } if(rafId) cancelAnimationFrame(rafId); }
+  function pauseAudio(){ if(!audioCtx) return; audioOffset=Math.max(0, audioCtx.currentTime-audioStart); stopAudio(); }
+  function scrubTo(sec){ if(!audioCtx||!audioBuf) return; sec=Math.max(0, Math.min(audioBuf.duration, sec)); audioOffset=sec; if(audioSrc) playAudio(); else { el.curTime.textContent=fmtTime(sec); el.scrub.value=''+Math.floor(sec); } }
+  function tick(){ if(!audioCtx||!audioBuf) return; const t=Math.min(audioBuf.duration, audioCtx.currentTime-audioStart); el.curTime.textContent=fmtTime(t); el.scrub.value=''+Math.floor(t); rafId=requestAnimationFrame(tick); }
+
+  /** Export */
+  function downloadBlob(blob, name){ const a=document.createElement('a'); const url=URL.createObjectURL(blob); a.href=url; a.download=name; document.body.appendChild(a); a.click(); setTimeout(()=>{URL.revokeObjectURL(url); a.remove();},700); }
+  function exportJSON(){ const data=JSON.stringify({project:'AudioVisual Storyboard',version:'2.1.1',bpm, markers, lanes:laneMeta, scenes}, null,2); downloadBlob(new Blob([data],{type:'application/json'}), `storyboard_${Date.now()}.json`); toast('JSON exporterad'); }
+  async function ensureLib(url){ return new Promise((res,rej)=>{ const s=document.createElement('script'); s.src=url; s.onload=()=>res(); s.onerror=()=>rej(new Error('load fail '+url)); document.head.appendChild(s); }); }
+  async function exportZIP(){
+    if(typeof JSZip==='undefined'){ await ensureLib('https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js'); }
+    const zip=new JSZip();
+    zip.file('project.json', JSON.stringify({project:'AudioVisual Storyboard',version:'2.1.1',bpm, markers, lanes:laneMeta, scenes}, null,2));
+    const imgFolder=zip.folder('images');
+    for(const s of scenes){ if(s.image_key){ const blob=await getImage(s.image_key); if(blob){ const buf=await blob.arrayBuffer(); imgFolder.file(`${s.id}.jpg`, buf); } } }
+    const out=await zip.generateAsync({type:'blob'}); downloadBlob(out, `AudioVisual_Storyboard_Bundle_${Date.now()}.zip`); toast('ZIP exporterad');
+  }
+  async function exportPDF(){
+    if(!(window.jspdf && window.jspdf.jsPDF)){ await ensureLib('https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js'); }
+    const { jsPDF } = window.jspdf;
+    const layout=Number(el.pdfLayout.value); const orient=el.pdfOrientation.value;
+    const title=el.pdfTitle.value||'AudioVisual Storyboard — Musikvideo';
+    const withCover=!!el.pdfCover.checked; const withLogo=!!el.pdfLogo.checked; const group=!!el.pdfGroup.checked;
+    const doc=new jsPDF({orientation:orient,unit:'pt',format:'a4'});
+    const pageW=doc.internal.pageSize.getWidth(), pageH=doc.internal.pageSize.getHeight();
+    const cols=(layout>=4)?2:1; const rows=(layout===1?1:(layout===2?2:(layout===4?2: (layout===6?3:4)))); // 6->3 rows, 12->4
+    const cells=cols*rows; const margin=24;
+    function cellRect(ix){ const cw=(pageW-margin*2-(cols-1)*margin)/cols; const ch=(pageH-margin*2-24-(rows-1)*margin)/rows; const c=ix%cells; const col=c%cols; const row=Math.floor(c/cols); const x=margin+col*(cw+margin); const y=margin+row*(ch+margin)+24; return {x,y,w:cw,h:ch}; }
+    function header(text){
+    doc.setFontSize(12); doc.setTextColor(30); doc.text(text, margin, 20);
+      if(withLogo){
+        doc.setDrawColor(200); doc.circle(pageW-margin-14, 16, 8, 'S'); doc.line(pageW-margin-20, 10, pageW-margin-6, 22);
+      }
+      doc.setDrawColor(180); doc.line(margin,26,pageW-margin,26);
+    }
+    function shotListPage(startIndex){
+      header(`${title} — Sammanfattning`);
+      const headY=40, rowH=18; let y=headY;
+      doc.setFontSize(10); doc.setTextColor(80);
+      doc.text('#', margin, y); doc.text('Titel', margin+24, y); doc.text('Start', margin+240, y); doc.text('Längd', margin+300, y); doc.text('Lane', margin+360, y); doc.text('Kamera', margin+420, y);
+      doc.setDrawColor(100); doc.line(margin,y+2,pageW-margin,y+2);
+      y+=10;
+      doc.setTextColor(30);
+      const perPage=Math.floor((pageH - (y+20))/rowH);
+      for(let i=startIndex;i<Math.min(scenes.length,startIndex+perPage);i++){
+        const s=scenes[i]; const ln=s.lane||0;
+        doc.text(String(s.scene_number||i+1), margin, y);
+        doc.text(String(s.title||'').slice(0,30), margin+24, y);
+        doc.text(fmtTime(s.startOffset||0), margin+240, y);
+        doc.text(String(s.duration||''), margin+300, y);
+        doc.text(String(laneMeta[ln]?.name||('L'+ln)), margin+360, y);
+        doc.text(String(s.camera_angle||''), margin+420, y);
+        y+=rowH;
+      }
+      return (startIndex+perPage);
+    }
+    scenes.sort((a,b)=>a.startOffset-b.startOffset);
+    if(withCover){
+      let idx=0;
+      while(idx<scenes.length){
+        idx=shotListPage(idx);
+        if(idx<scenes.length) doc.addPage();
+      }
+      doc.addPage();
+    }
+    function sceneHeaderRect(r, label){
+      if(!label) return;
+      doc.setTextColor(255,209,102); doc.setFontSize(10); doc.text(`Section: ${label}`, r.x, r.y-6);
+    }
+    function addSceneCell(i){
+      if(i%cells===0){ if(i>0) doc.addPage(); header(title); }
+      const s=scenes[i]; const r=cellRect(i);
+      const ih=r.h*0.62;
+      // Use light fill color for PDF cells for better print readability
+      doc.setDrawColor(200);
+      doc.setFillColor(255,255,255);
+      doc.rect(r.x,r.y,r.w,ih,'FD');
+      if(group){ const label=sectionLabelAt(s.startOffset||0); sceneHeaderRect(r,label); }
+      let imgData=null;
+      if(s.thumbnail_webp && s.thumbnail_webp.startsWith('data:image/webp')) imgData=s.thumbnail_webp; else if(s.thumbnail) imgData=s.thumbnail;
+      try{
+        if(imgData){
+          const imgType = imgData.startsWith('data:image/webp') ? 'WEBP' : 'JPEG';
+          // available drawing area within the image rectangle
+          const availW = r.w - 4;
+          const availH = ih - 4;
+          const aspect = 16/9;
+          let imgW = availW;
+          let imgH = imgW / aspect;
+          if(imgH > availH){
+            imgH = availH;
+            imgW = imgH * aspect;
+          }
+          const imgX = r.x + 2 + (availW - imgW)/2;
+          const imgY = r.y + 2 + (availH - imgH)/2;
+          doc.addImage(imgData, imgType, imgX, imgY, imgW, imgH);
+        }
+      }catch(e){}
+      const ln=s.lane||0;
+      const y2=r.y+ih+10;
+      // Primary text: dark for readability on light background
+      doc.setTextColor(30); doc.setFontSize(10);
+      doc.text(`Scen #${s.scene_number||''} — ${s.title||''}`.slice(0,80), r.x, y2);
+      // Secondary metadata text
+      doc.setTextColor(80);
+      doc.text(`Längd: ${s.duration||''}  Kamera: ${s.camera_angle||''}  Start: ${fmtTime(s.startOffset||0)}  ${laneMeta[ln]?.name||('L'+ln)}  ${s.locked?'[LÅST]':''}`, r.x, y2+14);
+      // Description text (dark)
+      doc.setTextColor(30);
+      const desc=(s.description||'').slice(0,260);
+      doc.text(doc.splitTextToSize(desc, r.w), r.x, y2+28);
+    }
+    for(let i=0;i<scenes.length;i++) addSceneCell(i);
+    doc.save(`AudioVisual_Storyboard_${Date.now()}.pdf`); toast('PDF exporterad');
+  }
+
+  /** Import */
+  function importJSON(file){
+    const fr=new FileReader(); fr.onload=()=>{ try{
+      const obj=JSON.parse(fr.result); const incoming=Array.isArray(obj)?obj:(obj.scenes||[]); const incMarkers=obj.markers||[]; const incLanes=obj.lanes||[];
+      scenes = incoming.map(x=>({ id:x.id||uid(), scene_number:Number(x.scene_number||0), title:x.title||'', description:x.description||'', duration:x.duration||'5s', camera_angle:x.camera_angle||'Medium', notes:x.notes||'', tags:x.tags||{camera:[],light:[],vfx:[]}, image_key:x.image_key||'', thumbnail:x.thumbnail||'', thumbnail_webp:x.thumbnail_webp||'', startOffset: (typeof x.startOffset==='number')?x.startOffset:null, lane: (typeof x.lane==='number')?x.lane:0, locked: !!x.locked, created_at:x.created_at||new Date().toISOString(), updated_at:x.updated_at||new Date().toISOString(), _durSec: parseSec(x.duration||'0') }));
+      markers = incMarkers.map(m=>({ t:Number(m.t)||0, label:m.label||m.type||'Marker', type:m.type||'Section' }));
+      laneMeta = Array.isArray(incLanes)&&incLanes.length? incLanes : laneMeta;
+      ensureDefaults(); renumberByTime(); save(); saveMarkers(); saveLanes(); selected.clear(); scheduleRender({scenes:true, timeline:true, overview:true}); toast('JSON importerad');
+    }catch(e){ alert('Ogiltig JSON: '+e.message); } }; fr.readAsText(file);
+  }
+
+  /** Wiring */
+  function switchView(name){ for(const [k,v] of Object.entries(el.view)) v.style.display=(k===name)?'block':'none'; for(const [k,b] of Object.entries(el.nav)) b.setAttribute('aria-current', k===name?'page':'false'); if(name==='timeline') renderTimeline(); if(name==='overview') renderOverview(); }
+  function renderLaneSettings(){
+    el.lanesBox.innerHTML='';
+    for(let ln=0; ln<laneCount; ln++){
+      const wrap=document.createElement('div'); wrap.className='toolbar';
+      wrap.innerHTML=`<span class="badge">Lane ${ln}</span>
+        <input type="text" value="${esc(laneMeta[ln]?.name||('Spår '+ln))}" data-ln="${ln}" data-k="name" style="width:140px">
+        <input type="color" value="${laneMeta[ln]?.color||'#8899aa'}" data-ln="${ln}" data-k="color" style="width:60px;height:40px;padding:0;border:none;border-radius:8px">
+        `;
+      wrap.querySelectorAll('input').forEach(inp=> inp.addEventListener('input', e=>{
+        const i=Number(e.target.getAttribute('data-ln')); const k=e.target.getAttribute('data-k'); laneMeta[i]=laneMeta[i]||{name:'Spår '+i, color:'#8899aa'}; laneMeta[i][k]=e.target.value; saveLanes(); scheduleRender({timeline:true, scenes:true});
+      }));
+      el.lanesBox.appendChild(wrap);
+    }
+  }
+  function wire(){
+    el.nav.scenes.onclick=()=>switchView('scenes'); el.nav.timeline.onclick=()=>switchView('timeline'); el.nav.overview.onclick=()=>switchView('overview'); el.nav.export.onclick=()=>switchView('export');
+    el.add.onclick=addScene;
+    // selection & bulk
+    el.selAll.onclick=()=>{ selected = new Set(scenes.map(s=>s.id)); updateSelBar(); scheduleRender({scenes:true}); };
+    el.selNone.onclick=()=>{ selected.clear(); updateSelBar(); scheduleRender({scenes:true}); };
+    el.bulkSetDur.onclick=bulkSetDuration; el.bulkSetCam.onclick=bulkSetCamera; el.bulkSetLane.onclick=bulkSetLane;
+    el.bulkDup.onclick=bulkDuplicate; el.bulkDel.onclick=bulkDelete;
+    el.bulkLock.onclick=()=>bulkLockScenes(true); el.bulkUnlock.onclick=()=>bulkLockScenes(false);
+    el.bulkAddTags.onclick=()=>applyTags('add'); el.bulkReplaceTags.onclick=()=>applyTags('replace'); el.bulkClearTags.onclick=()=>applyTags('clear');
+    // global quick tags
+    el.qtags.querySelectorAll('.qt').forEach(btn=> btn.addEventListener('click', ()=>{
+      const cat=btn.dataset.cat, val=btn.dataset.val;
+      const targets = selected.size? scenes.filter(s=>selected.has(s.id)) : scenes;
+      targets.forEach(s=>{ if(!s.locked){ s.tags=s.tags||{camera:[],light:[],vfx:[]}; const arr=s.tags[cat]||[]; if(!arr.includes(val)) arr.push(val); s.tags[cat]=arr; s.updated_at=new Date().toISOString(); }});
+      saveDebounced(); scheduleRender({scenes:true, overview:true}); toast(`Preset '${val}' applicerad (${targets.length})`);
+    }));
+    // timeline toolbar
+    el.tlFit.onclick=()=>{ const target=Math.max(1, Math.min(12, Math.floor(120/Math.max(1,scenes.length)))); scenes.forEach(s=>{ if(!s.locked) setDuration(s, `${target}s`); }); if(autoReflow) for(let ln=0; ln<laneCount; ln++) reflowLane(ln); saveDebounced(); scheduleRender({timeline:true}); toast('Auto-fit klart'); };
+    el.tlResolve.onclick=resolveOverlaps;
+    el.tlSnapToggle.onclick=()=>{ snapMode=(snapMode==='beat'?'marker':'beat'); el.tlSnapToggle.textContent='Snap: '+(snapMode==='beat'?'Beat':'Marker'); toast('Snap-läge: '+(snapMode==='beat'?'Beat':'Marker')); };
+    el.tlZoomIn.onclick=()=>{ timelinePxPerSec=Math.min(120, timelinePxPerSec+5); scheduleRender({timeline:true}); };
+    el.tlZoomOut.onclick=()=>{ timelinePxPerSec=Math.max(8, timelinePxPerSec-5); scheduleRender({timeline:true}); };
+    el.gridHard.onchange=()=>{ hardGrid=!!el.gridHard.checked; toast('Grid: '+(hardGrid?'Hard':'Soft')); };
+    el.gridQuant.onchange=()=>{ quantDiv = Number(el.gridQuant.value); toast('Quantize: '+(quantDiv===1?'1 beat':(quantDiv===0.5?'1/2':'1/4'))); };
+    el.reflowToggle.onchange=()=>{ autoReflow=!!el.reflowToggle.checked; toast('Auto-reflow: '+(autoReflow?'På':'Av')); };
+    // audio
+    el.bpm.oninput=()=>{ bpm=Number(el.bpm.value||120); beatMs=60000/Math.max(1,bpm); scheduleRender({timeline:true}); };
+    el.audioFile.onchange=e=>{ const f=e.target.files[0]; if(f) onAudioFile(f); };
+    el.play.onclick=()=>{ if(!audioSrc) playAudio(); else pauseAudio(); }; el.stop.onclick=()=>{ pauseAudio(); audioOffset=0; el.scrub.value='0'; el.curTime.textContent='0:00'; }; el.scrub.oninput=()=>scrubTo(Number(el.scrub.value||0));
+    // overview
+    el.fCat.oninput=()=>scheduleRender({overview:true}); el.fText.oninput=()=>{ ovPage=1; scheduleRender({overview:true}); };
+    el.ovPrev.onclick=()=>{ ovPage=Math.max(1,ovPage-1); scheduleRender({overview:true}); }; el.ovNext.onclick=()=>{ ovPage=ovPage+1; scheduleRender({overview:true}); };
+    // export
+    el.exportJson.onclick=exportJSON; el.exportJsonTop.onclick=exportJSON; el.exportZip.onclick=exportZIP; el.exportPdf.onclick=exportPDF;
+    // import
+    el.importJsonBtn.onclick=()=> el.importJsonFile.click(); el.importJsonFile.onchange=e=>{ const f=e.target.files[0]; if(f) importJSON(f); e.target.value=''; };
+    // images
+    el.importImages.onclick=()=> el.fileImages.click(); el.fileImages.onchange=e=>{ const files=[...(e.target.files||[])]; if(files.length) batchImportImages(files); e.target.value=''; };
+    // lanes
+    renderLaneSettings();
+    // markers clear & add
+    el.clearMarkers.onclick=()=>{ if(!markers.length) return toast('Inga markers'); if(!confirm('Rensa alla markers?')) return; markers.length=0; markDirty(); saveMarkers(); scheduleRender({timeline:true}); };
+    el.addAtCur.onclick=()=>{ const t=Number(el.scrub.value||0); const label=(el.mLabel.value||''); const type=(el.mType.value||'Section'); addMarkerAt(t,label,type); };
+    el.addManual.onclick=()=>{ const t=parseTimeStr(el.mTime.value); if(t==null) return alert('Ogiltig tid'); const label=(el.mLabel.value||''); const type=(el.mType.value||'Section'); addMarkerAt(t,label,type); };
+    el.alignMarkers.onclick=alignScenesToMarkers;
+
+  // Toggle selection bar visibility. This helps declutter the UI on small screens.
+  el.toggleSelbar.onclick=()=>{
+    el.selbar.classList.toggle('hidden');
+    updateThumbNavPosition();
+  };
+
+  // Auto-hide the selection bar on narrow viewports (e.g. mobile) at initial load
+  if(window.innerWidth < 900){
+    el.selbar.classList.add('hidden');
+  }
+
+  // Toggle actions menu visibility (mobile). Also reposition thumb nav.
+  el.toggleActions.onclick=()=>{
+    el.actions.classList.toggle('hidden');
+    updateThumbNavPosition();
+  };
+  // Auto-hide the actions menu on narrow viewports at initial load
+  if(window.innerWidth < 900){
+    el.actions.classList.add('hidden');
+  }
+
+  // Update thumbnail navigation when window is resized
+  window.addEventListener('resize', updateThumbNavPosition);
+  }
+
+  /** Init */
+  async function init(){
+    idb = await openDB();
+    scenes=load(); markers=loadMarkers(); laneMeta=loadLanes();
+    ensureDefaults(); renumberByTime(); renderScenes(); renderTimeline(); renderOverview(); wire();
+    bpm=Number(el.bpm.value||120); beatMs=60000/Math.max(1,bpm);
+  // position thumbnail navigation after initial render
+  updateThumbNavPosition();
+  }
+  document.addEventListener('DOMContentLoaded', init);
+})();
+</script>
+<script>
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", function() {
+    navigator.serviceWorker.register("service-worker.js");
+  });
+}
+</script>
+
+</body>
+</html>

--- a/apps/storyboard/dist/manifest.webmanifest
+++ b/apps/storyboard/dist/manifest.webmanifest
@@ -1,0 +1,23 @@
+{
+  "name": "AudioVisual Storyboard",
+  "short_name": "AV Storyboard",
+  "description": "Professional storyboard creation tool for audiovisual projects",
+  "start_url": ".",
+  "scope": ".",
+  "display": "standalone",
+  "display_override": ["fullscreen", "standalone"],
+  "background_color": "#0f1117",
+  "theme_color": "#1a1d29",
+  "icons": [
+    {
+      "src": "icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG — v2.2
 
+## 2026-02-24 — Build packaging fix for Netlify deploys
+- Updated the `npm run build` packaging command to archive the entire `apps/storyboard/dist` directory (`zip -qr app.zip .`) instead of hard-coding legacy filenames (`app.html`, `README.md`, `CHANGELOG.md`, `QA-rapport.md`, `vendor`).
+- This prevents Netlify build failures with `zip error: Nothing to do!` when those legacy files are absent and keeps packaging aligned with current dist contents.
+
+## 2026-02-24 — North Star release deck component
+- Added `apps/storyboard/dist/ReleasePlanDeck.jsx`, a React presentation component for the North Star Rising release and social media plan with slide navigation, keyboard controls, image upload support, and PDF export using `html2canvas` + `jsPDF`.
+- Enforced runtime-safe colors by centralizing hex/rgba theme tokens and avoiding Tailwind color utility classes that can compile to `oklch(...)` in constrained runtimes.
+- Included lightweight self-tests (`runSelfTests`) to assert non-`oklch` theme values and protect against future regressions.
+
 ## 2025-11-04 — Netlify Database bootstrap
 - Added a Netlify Database schema and seed files (`netlify/db/schema.sql`, `netlify/db/seed.sql`) so `npx netlify db init` provisions the posts table used by the `fetch-posts` function.
 - Documented the CLI helper for initializing the Netlify Database in `package.json` for consistent local setup.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "node tools/build/copy-standalone-assets.js && cd apps/storyboard/dist && rm -f app.zip && zip -qr app.zip app.html README.md CHANGELOG.md QA-rapport.md vendor",
+    "build": "node tools/build/copy-standalone-assets.js && cd apps/storyboard/dist && rm -f app.zip && zip -qr app.zip .",
     "test": "jest",
     "netlify:trigger": "node tools/netlify/trigger.js",
     "netlify:trigger:build": "node tools/netlify/trigger.js build",


### PR DESCRIPTION
### Motivation

- Ship a standalone “release plan” presentation component and static UI so teams can produce a portable release deck and export PDFs. 
- Avoid runtime failures caused by Tailwind color tokens compiling to `oklch(...)` by centralizing color tokens as hex/rgba and removing Tailwind color utilities in the deck component. 
- Fix Netlify packaging errors caused by hard-coded filenames during build by making the dist zipping step archive the whole `apps/storyboard/dist` directory.

### Description

- Added `apps/storyboard/dist/ReleasePlanDeck.jsx`, a React slide-deck component implementing slide navigation, keyboard controls, local image upload, offscreen render for PDF export and PDF generation via `html2canvas` + `jsPDF`, with a centralized `THEME` using hex/rgba inline styles. 
- Added a complete static `apps/storyboard/dist/index.html` and `apps/storyboard/dist/manifest.webmanifest` to serve the storyboard UI as a standalone web app (dark theme, timeline, scenes, overview, export tools). 
- Changed the build packaging command in `package.json` to `zip -qr app.zip .` so `npm run build` archives the entire `dist` directory instead of relying on legacy filenames. 
- Updated `docs/CHANGELOG.md` to document the new deck component and the Netlify build packaging fix, and added lightweight runtime self-tests (`runSelfTests`) to assert the theme contains hex/rgba and no `oklch` tokens.

### Testing

- The deck includes a runtime self-test (`runSelfTests`) that validates `THEME` values are hex/rgba and not `oklch(...)`, and these assertions are invoked on component mount and passed in our runtime smoke run. 
- Verified packaging by running `npm run build` which now zips the `apps/storyboard/dist` directory successfully and avoids the previous `zip error: Nothing to do!` failure. 
- No unit test changes were required; existing test command remains `npm test` (`jest`) and was not modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e2dd72a80832e8a0632b2bf283045)