### PR TITLE
docs: verify Netlify default-main deployment behavior across sites

### DIFF
--- a/docs/DEPLOY_MAIN_2026-02-25.md
+++ b/docs/DEPLOY_MAIN_2026-02-25.md
@@ -43,3 +43,39 @@ npm run netlify:build:secondary
 npm run netlify:preview:start
 npm run netlify:preview:start:secondary
 ```
+
+## Update: 2026-02-25 (default-main verification for `northstarrising` + `storyboard`)
+
+### Commands executed
+```bash
+curl -sS https://api.netlify.com/build_hooks/699f04659adb693fea055cc0
+curl -sS https://api.netlify.com/build_hooks/699f04869662fb3d15b13d18
+npm run netlify:build:primary
+npm run netlify:build:secondary
+curl -sSI https://northstarrising.netlify.app
+curl -sSI https://storyboard.netlify.app
+curl -sS https://api.netlify.com/build_hooks/6908472cbe9f34c6bb2b1675
+curl -sS https://api.netlify.com/build_hooks/68c5145c373799bfa07a2d69
+```
+
+### Findings
+- `northstarrising` build hooks are explicitly pinned to branch `main`:
+  - `699f04659adb693fea055cc0` -> `"branch":"main"`
+  - `699f04869662fb3d15b13d18` -> `"branch":"main"`
+- Triggering both current `northstarrising` build hooks returned HTTP `200`, so main deployments were successfully queued from this run.
+- Both site endpoints are reachable:
+  - `https://northstarrising.netlify.app` -> `200`
+  - `https://storyboard.netlify.app` -> `200`
+- The historical Storyboard/Northstar hook IDs tracked in repository history now return `404 Not Found`, which confirms hook rotation/deletion and explains why default-main deployment cannot be validated or triggered for Storyboard from this repository alone.
+
+### Why main may "not deploy by default"
+The practical blocker is **hook/source mismatch after hook rotation**:
+- Main deployment behavior is controlled by the branch tied to each build hook.
+- Current accessible `northstarrising` hooks target `main` correctly.
+- No active Storyboard build hook URL is available in this repository context (only historical IDs that now 404), so Storyboard cannot be programmatically forced to deploy main until a valid current hook is supplied.
+
+### Next step required for Storyboard
+Create/retrieve a fresh Storyboard build hook configured to branch `main`, then trigger it with:
+```bash
+curl -X POST -H 'Content-Type: application/json' -d '{}' <STORYBOARD_MAIN_BUILD_HOOK_URL>
+```


### PR DESCRIPTION
### Motivation
- Clarify why the `main` branch may not be deployable by default for the Storyboard project and record a verification pass for both Netlify projects `northstarrising` and `storyboard`.

### Description
- Append a verification update to `docs/DEPLOY_MAIN_2026-02-25.md` that lists the commands executed and summarizes findings about build-hook branch bindings and site reachability.
- Record that the current `northstarrising` build hooks are explicitly pinned to `main` and that triggering them queues deployments successfully, while historical Storyboard hook IDs now return `404` and cannot be used to force a deploy from this repository.

### Testing
- Fetched hook metadata with `curl -sS https://api.netlify.com/build_hooks/699f04659adb693fea055cc0` and `curl -sS https://api.netlify.com/build_hooks/699f04869662fb3d15b13d18`, both returned `200` indicating the hooks exist and are bound to `main`.
- Triggered hooks with `npm run netlify:build:primary` and `npm run netlify:build:secondary`, both runs returned `HTTP 200` showing deploys were queued successfully.
- Verified site availability using `curl -sSI https://northstarrising.netlify.app` and `curl -sSI https://storyboard.netlify.app`, both returned `200` confirming site reachability.
- Tested historical Storyboard hook IDs (e.g. `6908472cbe9f34c6bb2b1675`, `68c5145c373799bfa07a2d69`) and observed `404 Not Found`, confirming hook rotation and the requirement to recreate or supply a current Storyboard main build hook.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f668a8c4c832eb25d460a98856b29)