### PR TITLE
Point Netlify hooks and docs to Storyboard project (build + preview hooks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,18 +108,19 @@ Helpful Netlify links:
 
 
 ## Project Netlify endpoints
-- Site URL: https://northstarrising.netlify.app
-- Build hook (primary): `https://api.netlify.com/build_hooks/699f04659adb693fea055cc0`
-- Build hook (secondary): `https://api.netlify.com/build_hooks/699f04869662fb3d15b13d18`
-- Preview server hook (primary): `https://api.netlify.com/preview_server_hooks/699f04f7bcd708545509329f`
-- Preview server hook (secondary): `https://api.netlify.com/preview_server_hooks/699f050e9adb693f160565c9`
+- Site URL: https://storyboard-app.netlify.app
+- Netlify HUD URL: https://storyboard-app.netlify.app/?netlify_hud=66a4ee6c-ce0b-4d08-ae98-adf7c519c274
+- Build hook (main branch): `https://api.netlify.com/build_hooks/699f69191cda8ca13efd3832`
+- Preview server hook (primary): `https://api.netlify.com/preview_server_hooks/699f699f162a30a4836c4747`
+- Preview server hook (secondary): `https://api.netlify.com/preview_server_hooks/699f69c15673bfa8b7826282`
 
 Quick triggers (uses committed defaults but can be overridden by env vars):
 ```bash
-export NETLIFY_BUILD_HOOK_PRIMARY='https://api.netlify.com/build_hooks/699f04659adb693fea055cc0'
-export NETLIFY_BUILD_HOOK_SECONDARY='https://api.netlify.com/build_hooks/699f04869662fb3d15b13d18'
-export NETLIFY_PREVIEW_SERVER_HOOK='https://api.netlify.com/preview_server_hooks/699f04f7bcd708545509329f'
-export NETLIFY_PREVIEW_SERVER_HOOK_SECONDARY='https://api.netlify.com/preview_server_hooks/699f050e9adb693f160565c9'
+export NETLIFY_BUILD_HOOK_PRIMARY='https://api.netlify.com/build_hooks/699f69191cda8ca13efd3832'
+# Optional only if you have a second build hook configured:
+# export NETLIFY_BUILD_HOOK_SECONDARY='https://api.netlify.com/build_hooks/<your-secondary-hook-id>'
+export NETLIFY_PREVIEW_SERVER_HOOK='https://api.netlify.com/preview_server_hooks/699f699f162a30a4836c4747'
+export NETLIFY_PREVIEW_SERVER_HOOK_SECONDARY='https://api.netlify.com/preview_server_hooks/699f69c15673bfa8b7826282'
 
 npm run netlify:build:primary
 npm run netlify:build:secondary
@@ -134,7 +135,7 @@ Local development note:
 
 If you prefer raw curl:
 ```bash
-curl -X POST -H 'Content-Type: application/json' -d '{}' https://api.netlify.com/preview_server_hooks/699f04f7bcd708545509329f
+curl -X POST -H 'Content-Type: application/json' -d '{}' https://api.netlify.com/preview_server_hooks/699f69c15673bfa8b7826282
 ```
 
 ## Security note
@@ -155,7 +156,7 @@ For a concrete phased plan to support editable text/fields, image uploads, onlin
 
 
 Netlify Deploy Permalink:
-- Use the latest successful deploy URL from the Netlify Deploys tab for `northstarrising` (permalink changes per deploy).
+- Use the latest successful deploy URL from the Netlify Deploys tab for `storyboard-app` (permalink changes per deploy).
 
 ## Optional server sync (web ↔ mobile)
 The app now supports optional remote sync if a backend endpoint is configured:

--- a/docs/NETLIFY_ACCESS.md
+++ b/docs/NETLIFY_ACCESS.md
@@ -1,19 +1,26 @@
 # Netlify access details
 
 ## Site
-- Canonical URL: https://northstarrising.netlify.app
-- Optional debug URL (Netlify HUD): https://northstarrising.netlify.app/?netlify_hud=679b85e1-7631-44b3-a3af-72d258120832
+- Canonical URL: https://storyboard-app.netlify.app
+- Optional debug URL (Netlify HUD): https://storyboard-app.netlify.app/?netlify_hud=66a4ee6c-ce0b-4d08-ae98-adf7c519c274
 
 ## Build hooks
-- Primary: https://api.netlify.com/build_hooks/699f04659adb693fea055cc0
-- Secondary: https://api.netlify.com/build_hooks/699f04869662fb3d15b13d18
+- Main branch (primary): https://api.netlify.com/build_hooks/699f69191cda8ca13efd3832
+- Secondary: not currently defined in this repository defaults (set `NETLIFY_BUILD_HOOK_SECONDARY` if needed)
 
 ## Preview server hooks
-- Primary: https://api.netlify.com/preview_server_hooks/699f04f7bcd708545509329f
-- Secondary: https://api.netlify.com/preview_server_hooks/699f050e9adb693f160565c9
+- Primary: https://api.netlify.com/preview_server_hooks/699f699f162a30a4836c4747
+- Secondary: https://api.netlify.com/preview_server_hooks/699f69c15673bfa8b7826282
+
+## Storyboard SSH key
+Use this key where Netlify/Git provider deploy-key setup requires it:
+
+```text
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCeSsolRA68KEGkixal5nf8NwKSjdDavkjc+xiHBUJ71IxfqcydkguG8qbLKm0Oo5b9+Yizimom0tO0VDiE9i/tfDb1E54dklTtpdrVE+Jy3+GG4Vay3QwP+kmCMa+0oscV0t05MOSm08/48S2KtxoTuA8lsPLPUKzlZReCe+jF5EbEukgQBw65FehGNBmQlDo8xGd4Msk/RUGqaNeaUcDOBOLNw8cL8Q5mkkJyzeeyH75uN7jNlrfBWvyNPfT2ysuBDlEg6i/JvM7gIr2W6HBWBNPfVqRZifE+DLkBG7wKo4OyXSYHNKwn0OIPhZxAh9TGn6YWppIcnJ2keCOADTuP2epWEsS0WjJFmvMSvSxEp4gngL5+podsrUDbev3E/f2ZMV1ouy3mprU0e7Nc6MNlhjnuEnuDB96SFqUaBVjer5MWpQe9d9EAS8/PA0P69MUZD2jcYzv5Mlb9Z01jvtiG8v3Hxec6mqNssU44zHwIpYgmSiF0ShtchUj8EHty7wJuN+Atf5QuFlCsFzTNTo/dPU7B1Q9WrmiZ8VbM/wE9/LR/pAtcuHXqxZveBtau/AZAsDEEGawTZIxg2WbiDORqcLPq2hK6WXtHtJItqrmG7bBro/GElVWwdPxbFaZ4k0iCQ0xNCWxTbq3dx14SlawwuEe9MVuwndCn/sR8Ptc7hw==
+```
 
 ## Trigger commands
-These npm commands now include robust status parsing (final HTTP code) and clear failure output.
+These npm commands include robust status parsing (final HTTP code) and clear failure output.
 They use the hook URLs above by default and allow env-var override when needed.
 
 ```bash
@@ -28,6 +35,13 @@ Override variables (optional):
 - `NETLIFY_BUILD_HOOK_SECONDARY`
 - `NETLIFY_PREVIEW_SERVER_HOOK`
 - `NETLIFY_PREVIEW_SERVER_HOOK_SECONDARY`
+
+## Quick curl triggers
+
+```bash
+curl -X POST -d {} https://api.netlify.com/preview_server_hooks/699f69c15673bfa8b7826282
+curl -X POST -d {} https://api.netlify.com/preview_server_hooks/699f699f162a30a4836c4747
+```
 
 ## Optional local Netlify tooling
 
@@ -44,13 +58,7 @@ Prefer `npx` over global installs to avoid version drift:
 npx netlify dev
 ```
 
-## Verified relation matrix (2026-02-25)
-- Site slug: `northstarrising`
-- Badge UUID: `679b85e1-7631-44b3-a3af-72d258120832`
-- Netlify deploys page: `https://app.netlify.com/projects/northstarrising/deploys`
-- Badge URL: `https://api.netlify.com/api/v1/badges/679b85e1-7631-44b3-a3af-72d258120832/deploy-status`
-
-Hook relation mapping used by `scripts/netlify-hook-trigger.mjs`:
+## Hook relation mapping used by `scripts/netlify-hook-trigger.mjs`
 - `primary` -> `NETLIFY_BUILD_HOOK_PRIMARY`
 - `secondary` -> `NETLIFY_BUILD_HOOK_SECONDARY`
 - `preview` -> `NETLIFY_PREVIEW_SERVER_HOOK`

--- a/scripts/netlify-hook-trigger.mjs
+++ b/scripts/netlify-hook-trigger.mjs
@@ -13,10 +13,10 @@ const HOOK_ENV = {
 
 
 const DEFAULT_HOOK_URL = {
-  primary: 'https://api.netlify.com/build_hooks/699f04659adb693fea055cc0',
-  secondary: 'https://api.netlify.com/build_hooks/699f04869662fb3d15b13d18',
-  preview: 'https://api.netlify.com/preview_server_hooks/699f04f7bcd708545509329f',
-  'preview:secondary': 'https://api.netlify.com/preview_server_hooks/699f050e9adb693f160565c9',
+  primary: 'https://api.netlify.com/build_hooks/699f69191cda8ca13efd3832',
+  secondary: '',
+  preview: 'https://api.netlify.com/preview_server_hooks/699f699f162a30a4836c4747',
+  'preview:secondary': 'https://api.netlify.com/preview_server_hooks/699f69c15673bfa8b7826282',
 };
 
 const LABEL = {


### PR DESCRIPTION
### Motivation
- Replace historical Netlify endpoints that no longer applied to this repo with the new Storyboard project hook URLs so main branch deployments and preview triggers can be invoked from repository scripts and docs.
- Provide the Storyboard HUD, preview curl examples, and an SSH deploy key to make Netlify/Git provider setup and on-call troubleshooting straightforward.

### Description
- Updated default hook targets in `scripts/netlify-hook-trigger.mjs` to use the Storyboard build hook and preview server hooks and left the secondary build hook intentionally unset so it must come from `NETLIFY_BUILD_HOOK_SECONDARY` if required.
- Reworked the Netlify section in `README.md` to reference `storyboard-app.netlify.app`, include the HUD link, and update the quick `export` examples to the new hook defaults.
- Replaced `docs/NETLIFY_ACCESS.md` with Storyboard-specific access details, added the provided SSH public key, and added quick `curl` triggers for the preview hooks.
- Minor cleanup: swapped a preview curl example in `README.md` to the new preview hook endpoint to match the updated defaults.

### Testing
- Ran `npm run netlify:build:primary` and observed a successful trigger (`HTTP 200`).
- Ran `npm run netlify:preview:start` and `npm run netlify:preview:start:secondary` and observed successful triggers (`HTTP 200`).
- Executed direct `curl -X POST -d {} <preview_hook_url>` calls for both preview hooks and received `200` responses.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f6b017cf4832e97a0234d96f161cd)