### PR TITLE
[Archived] Add Assets/.gitkeep to superseded Storyboard tree

### DIFF
--- a/Assets/.gitkeep
+++ b/Assets/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder file to keep the Assets directory in git.


### PR DESCRIPTION
Closed during the NullForge Simulation Lab repository rebase on 2026-07-10. This pull request targets the superseded Storyboard codebase preserved on `archive/pre-nullforge-rebase-2026-07-10`; it must not be merged into the new canonical `main`.