### PR TITLE
Add fail-closed sparse-hit detector candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - Record that no active Three.js implementation was identified on `main`; visualization status remains preimplementation rather than validated.
 - Restore the exact Preview Lab v0.1 runtime blobs previously validated in closed mirror PR #113, add current structural regression tests and retain the explicit `PREVIEW / NOT TRUTH ENGINE` evidence boundary.
 - Keep schema/workflow restoration outside this safe-UI scope; auditory, mobile and deterministic-browser validation remain open gates.
+- Add sparse-hit detector candidate v0.1 with robust onset proposals, broadband/flatness/persistence features, fail-closed classifications, versioned parameters and machine-readable candidate reports.
+- Add seven deterministic synthetic fixture tests covering sparse hits, bass rejection, low-synth rejection, edit-boundary handling, stereo input and parameter-hash mutation; all outputs remain `HYPOTHESIS` pending human/source validation.
 
 Remaining external enforcement work:
 

--- a/ai/control-report.md
+++ b/ai/control-report.md
@@ -1,94 +1,118 @@
 # AI Gate Control Report
 
-Task ID: `RESTORE_PREVIEW_LAB_V0_1_20260712`  
-Branch: `ui/restore-preview-lab-v0-1-20260712`  
-Base commit: `713697d4eaa8f54896b62dd1eff3a10e01331b9f`
+Task ID: `SPARSE_HIT_DETECTOR_V0_1_20260712`  
+Branch: `research/sparse-hit-detector-v0-1-20260712`  
+Base commit: `0c100a6399a2fb1d07653cd6c4eff9e12e23957a`
 
 ## Project purpose
 
-NullForge separates canonical offline DSP evidence from interactive browser exploration. The Preview Lab is useful only when it remains visibly noncanonical, structurally inspectable and subordinate to the Python/Rust evidence path.
+NullForge separates exploratory DSP hypotheses from canonical measured evidence. A useful detector must expose its feature contract, parameter set, failure classes and limitations rather than converting low-frequency transients into confident instrument labels.
 
 ## Current task
 
-Restore the Preview Lab v0.1 browser runtime that previously passed structural and exchange validation in closed mirror PR #113 but was absent from current `main`. Restore only the six unprotected `web/` runtime artifacts, add current Python structural tests, document provenance and keep protected schemas, validators and workflows outside this safe-UI scope.
+Publish sparse-hit detector candidate v0.1 using only deterministic synthetic fixtures. The candidate proposes broadband sparse transients, rejects sustained bass-like attacks, fails ambiguous edit boundaries closed, hashes its configuration and labels every output `HYPOTHESIS`.
 
 ## Mandatory files read
 
-All ten files configured by `docs/governance/AI_GATE_CONFIG.json` were read or verified against `main@713697d4eaa8f54896b62dd1eff3a10e01331b9f`. Current base hashes were recorded before editing. The browser/WASM and visualization contracts merged in PR #126 were also used as task-specific constraints.
-
-## Source provenance
-
-The restored runtime uses exact existing Git blob objects from PR #113 head `74260dbdd3449c3f07b637a260b2cb991a0880bb`:
-
-- `web/index.html` → `e8f4b9999eb3f4e456ee4d672537aa0b6696fbda`
-- `web/app.js` → `9fdc7cb8c49bc7d944c6edb25061a0f09a9b0eb9`
-- `web/styles.css` → `dcc0c6b6d434f853d97308a9a89e21ddd230ef74`
-- `web/session-contract.js` → `febca46d7b14ee3b4581ac46aaaff6c42464be17`
-- `web/README.md` → `ccda2bc244894c735717b9614b984162fe344980`, subsequently extended only with restoration provenance and current claim limits
-- `web/examples/preview-session.example.json` → `65c385c2511714a792513aa1172a8cb77295b5cd`
-
-PR #113 passed its then-current Reference CI and was deliberately closed without merge. Its historical result is evidence for the source blobs, not an automatic pass for this restoration branch.
+All ten files configured by `docs/governance/AI_GATE_CONFIG.json` were read or verified against `main@0c100a6399a2fb1d07653cd6c4eff9e12e23957a`. Current base hashes were recorded before editing. The scientific-integrity policy and repository architecture were treated as binding: the detector cannot alter canonical scenarios, reference outputs or previously verified DSP scope.
 
 ## What absolutely must not be changed
 
-This task must not alter AI Gate, workflows, schemas, protected validators, Reference CI authority, Rust/Python DSP code, scenarios, deployment configuration or external repository rules. It must not claim auditory correctness, mobile usability, deterministic Web Audio timing, Rust/WASM parity or Three.js validity.
+This task must not modify AI Gate, Reference CI, protected schemas, scenarios, reference runners, Rust core, deployment, Preview Lab behavior or external rules. It must not include private audio, FTC source material, copied commercial recordings or claims of real-instrument validation. It must not promote confidence as probability or `SPARSE_HIT` as instrument identity.
 
 ## Latest stable / green version
 
-The branch starts from `main@713697d4eaa8f54896b62dd1eff3a10e01331b9f`, the merge commit for PR #126 and the current browser/visual-contract baseline.
+The branch starts from `main@0c100a6399a2fb1d07653cd6c4eff9e12e23957a`, the merge commit for PR #127 and the current green Preview Lab restoration baseline.
 
 ## Approved scope
 
-The implementation scope is limited to the six restored `web/` runtime files, `tests/test_preview_lab_files.py`, and substantive updates to `CHANGELOG.md` and `docs/STATE.md`. The required proof and control report are always-allowed task artifacts.
+The task is limited to:
 
-No `schemas/**`, `.github/**`, `docs/governance/**`, `tools/ai_gate/**`, `reference/**`, `scenarios/**`, `crates/**` or deploy files may enter the diff.
+- `research/sparse_hit_detector.py`;
+- `tests/test_sparse_hit_detector.py`;
+- `docs/SPARSE_HIT_DETECTOR_CANDIDATE.md`;
+- substantive `CHANGELOG.md` and `docs/STATE.md` updates.
 
-## Safety and authority review
+The required proof and control report are always-allowed task artifacts. No protected path may enter the diff.
 
-- The page visibly states `PREVIEW / NOT TRUTH ENGINE`.
-- Runtime state declares `preview_not_truth_engine`.
-- Snapshots remain labeled `PREVIEW_SNAPSHOT_NOT_DETERMINISTIC_EVIDENCE`.
-- Browser Web Audio and canvas animation do not replace integer-sample offline authority.
-- The restored app uses no external runtime dependency, private API, credential, Drive/Notion reference, `eval` or dynamic function constructor.
-- The restoration does not include Three.js and makes no Three.js validation claim.
-- The example session and runtime remain public synthetic material.
+## Candidate design
 
-## Regression tests
+The proposal stage calculates positive spectral flux in four declared frequency regions and compares total flux against a rolling robust baseline. A refractory interval suppresses multiple proposals from one decay.
 
-`tests/test_preview_lab_files.py` checks:
+For each proposal, the detector records:
 
-- all expected runtime artifacts exist;
-- HTML asset wiring and principal controls/canvases are present;
-- preview-only mode and evidence labels remain intact;
-- prohibited dynamic evaluation constructs are absent;
-- the example session is parseable and noncanonical;
-- the session contract retains sample-addressed automation structure.
+- integer sample index and seconds derived from the declared sample rate;
+- low, low-mid, upper-mid and high attack-power shares;
+- number of active bands;
+- attack spectral flatness;
+- 80–160 ms persistence relative to the first 30 ms;
+- transparent heuristic confidence;
+- class, detector version, parameter hash and evidence class.
+
+The class boundary is explicit:
+
+- `SPARSE_HIT` requires broadband attack evidence, sufficient flatness and limited persistence;
+- `BASS_ATTACK` requires low/low-mid dominance, spectral concentration and persistence;
+- `UNRESOLVED_TRANSIENT` preserves ambiguous proposals;
+- `NO_EVENT` rejects insufficient attack energy.
+
+## Synthetic fixture evidence
+
+Seven deterministic local tests passed before publication:
+
+1. sparse kick with broadband click → `SPARSE_HIT` near the inserted sample;
+2. cinematic low hit with broadband crack → `SPARSE_HIT` with at least three active bands;
+3. sustained bass pluck → `BASS_ATTACK`;
+4. low synth stab → not `SPARSE_HIT`;
+5. edit boundary → `UNRESOLVED_TRANSIENT`;
+6. parameter mutation → different parameter hash;
+7. identical stereo input → supported and classified consistently.
+
+These fixtures demonstrate only the implemented contract on those synthetic signals. They do not establish population precision, recall or real-source validity.
+
+## Publication-boundary review
+
+The implementation, fixtures and documentation are entirely synthetic and public. They contain no Drive/Notion links, internal IDs, source audio, private project mappings, credentials or raw conversations. The candidate creates no network, filesystem-discovery or model dependency.
+
+## Scientific risks and mitigations
+
+- **Fixture overfitting:** thresholds may fit the initial examples. Mitigation: label as candidate, publish thresholds, preserve failures and require a broader matrix before promotion.
+- **False instrument identity:** flatness and persistence are not percussion-specific. Mitigation: `SPARSE_HIT` is a signal hypothesis, not a drum label.
+- **Mono reduction:** channel-specific evidence may be lost. Mitigation: document limitation and retain stereo support only as deterministic reduction, not spatial inference.
+- **Confidence misuse:** heuristic confidence is not calibrated probability. Mitigation: state this explicitly and retain the feature vector.
+- **Threshold drift:** later tuning could silently alter behavior. Mitigation: deterministic parameter hash and versioned candidate status.
 
 ## Risk class
 
-`R1_SAFE_UI` is appropriate because the change restores an interactive static browser surface and adds non-protected tests. It does not alter protected schemas, DSP/scientific logic, governance, deployment or canonical evidence generation.
+`R3_DSP_OR_SCIENCE` is required because the task introduces signal-analysis logic and scientific classification language, even though it does not touch protected reference or scenario paths.
 
 ## Required tests
 
-The fixed `R1_SAFE_UI` profile requires:
+The fixed R3 profile requires:
 
-- `unit_tests`
-- `public_boundary`
+- `unit_tests`;
+- `reference_experiment`;
+- `public_boundary`.
 
-The independent Reference CI status remains a manual merge requirement. AI Gate must additionally validate exact branch/base binding, mandatory hashes, allowed paths, state updates, report content and final-commit evidence.
+The reference experiment must remain unchanged and pass independently, proving that the candidate did not contaminate canonical outputs. Reference CI must be green on the exact PR head. AI Gate must validate branch/base binding, hashes, exact scope, state updates and report content.
 
-## Remaining limitations
+## Promotion boundary
 
-- Runtime auditory behavior still requires human listening.
-- Android/mobile interaction still requires device QA.
-- The example exchange format is not restored as a protected public schema in this PR.
-- Web Audio remains preview-only and not deterministic evidence.
-- Rust/WASM and Three.js implementations remain absent.
+Real-source use remains blocked until all of the following are recorded:
+
+- exact input and parameter digests;
+- a broader synthetic and public-domain fixture matrix;
+- false-positive and false-negative reporting;
+- human listening adjudication of candidate windows;
+- explicit treatment of unresolved identity;
+- a reviewed decision about whether the candidate is useful as an exploratory prior.
+
+A later pass cannot erase failures from v0.1.
 
 ## Rollback plan
 
-Close without merge if blob provenance, preview labeling, scope or tests fail. After merge, revert only the restored `web/` runtime, the structural test and corresponding state/changelog entries. Preserve PR #113 history, PR #126 contracts, AI Gate, Reference CI and all canonical evidence.
+Close without merge if fixture behavior, determinism, scope, labeling or required tests fail. After merge, revert the implementation, tests, candidate document and state/changelog entries together. Preserve canonical experiments, Reference CI, prior measurements and failure provenance.
 
 ## Agent assertion
 
-This restoration makes an already reviewed preview surface runnable again without silently importing protected architecture or inflating its evidence status. It advances issue #123 from missing-runtime blockage toward human auditory and mobile QA, but does not complete that QA.
+This change turns a vague detector idea into a reproducible and falsifiable candidate. It deliberately stops short of claiming that any real production layer has been identified.

--- a/ai/session-proof.json
+++ b/ai/session-proof.json
@@ -1,14 +1,14 @@
 {
   "schema_version": "0.2.1",
-  "task_id": "RESTORE_PREVIEW_LAB_V0_1_20260712",
-  "branch": "ui/restore-preview-lab-v0-1-20260712",
-  "base_commit": "713697d4eaa8f54896b62dd1eff3a10e01331b9f",
+  "task_id": "SPARSE_HIT_DETECTOR_V0_1_20260712",
+  "branch": "research/sparse-hit-detector-v0-1-20260712",
+  "base_commit": "0c100a6399a2fb1d07653cd6c4eff9e12e23957a",
   "agent": {
     "name": "ChatGPT",
     "model_or_runtime": "GPT-5.6 Thinking / GitHub connector",
     "operator": "human_project_arbiter"
   },
-  "created_at": "2026-07-12T04:58:00Z",
+  "created_at": "2026-07-12T05:09:00Z",
   "mandatory_files": [
     "AGENTS.md",
     "README.md",
@@ -27,40 +27,37 @@
     "ARCHITECTURE.md": "sha256:d1710e752dac3b992c39d0fb777f7993686bfd5835be433abad6b1b3127904fc",
     "SCIENTIFIC_INTEGRITY.md": "sha256:0e5c9beabb486e761d4f3511dbde8cf726fe8af8365f24b24b87de821eb40bac",
     "PUBLICATION_BOUNDARY.md": "sha256:c5e685a531565fd3bd60bbca3c7c5e32da42d00c6908b388688bb8951fb60ec0",
-    "CHANGELOG.md": "sha256:5a962967d6562d1206989683ac3b223554cd50186322ef10f350c0af3a24af78",
-    "docs/STATE.md": "sha256:9572d12bf4985d92e32a1528c4175795c83f03d4c86ead66e720d8ca82cf68cc",
+    "CHANGELOG.md": "sha256:d96bd3a9f305a15cdc7e5178272eff16f420e108ae8db44c505be7516f47f430",
+    "docs/STATE.md": "sha256:5a7267426f41da60a6ead17f3ec16e726d5482a551edcb84198377cb881cda52",
     "docs/governance/AI_GATE_RULESET.md": "sha256:e99e54e5b44c1b05b872589a56132a965029b7cbe43a92334c07e51ba9c1191f",
     "docs/governance/AI_GATE_CONFIG.json": "sha256:31f10fe92713c5003f43fa0dc4e558e56f965406f1c89ddbab1e1e19b41499d7",
     "schemas/ai-session-proof.schema.json": "sha256:f45d2f45e1289de9260e6c34e99998e90a67b06392f75cacd53379c3ff766068"
   },
-  "project_state_summary": "NullForge has AI Gate v0.2.1 PATCH-2 active, Reference CI as scientific authority, explicit browser/WASM and visualization contracts, and a Preview Lab v0.1 runtime previously validated in a closed mirror PR but absent from current main.",
-  "current_task_summary": "Restore the exact previously validated Preview Lab v0.1 browser runtime blobs to a safe-UI branch, add current structural regression tests and preserve the preview-only evidence boundary without restoring protected schemas or workflows.",
+  "project_state_summary": "NullForge has AI Gate v0.2.1 PATCH-2 active, Reference CI as scientific authority, browser and visualization contracts, a restored Preview Lab runtime and an internal backlog item for a fail-closed sparse-hit detector.",
+  "current_task_summary": "Publish a deterministic synthetic-only sparse-hit detector candidate with transparent features, parameter hashing, fail-closed classifications, seven fixture tests and explicit hypothesis-level evidence boundaries.",
   "must_not_change": [
     "AI Gate workflow, validator, configuration, schema, test runner or external ruleset state",
-    "Reference CI authority, DSP core, scientific baselines, protected schemas or evidence classes",
-    "browser/WASM parity claims, auditory QA status, mobile QA status or Three.js validation status",
-    "deployment configuration, Netlify behavior, private workspace separation or unpublished source material"
+    "Reference CI authority, canonical scenarios, reference outputs, Rust core or previously verified DSP scope",
+    "private source audio, internal workspace material, unpublished claims or copyrighted fixtures",
+    "Preview Lab runtime behavior, deployment configuration, browser/WASM parity claims or visualization validity"
   ],
-  "latest_green_version": "main@713697d4eaa8f54896b62dd1eff3a10e01331b9f",
+  "latest_green_version": "main@0c100a6399a2fb1d07653cd6c4eff9e12e23957a",
   "allowed_paths": [
     "CHANGELOG.md",
     "docs/STATE.md",
-    "tests/test_preview_lab_files.py",
-    "web/README.md",
-    "web/app.js",
-    "web/examples/preview-session.example.json",
-    "web/index.html",
-    "web/session-contract.js",
-    "web/styles.css"
+    "docs/SPARSE_HIT_DETECTOR_CANDIDATE.md",
+    "research/sparse_hit_detector.py",
+    "tests/test_sparse_hit_detector.py"
   ],
   "additional_forbidden_paths": [],
   "approved_context_changes": [],
-  "risk_class": "R1_SAFE_UI",
+  "risk_class": "R3_DSP_OR_SCIENCE",
   "required_test_ids": [
     "unit_tests",
+    "reference_experiment",
     "public_boundary"
   ],
-  "rollback_plan": "Close the pull request without merge if the restored blobs differ from the validated PR #113 source, if preview-only labeling is weakened, if protected files enter the diff or if current unit/public-boundary tests fail. After merge, revert only the Preview Lab runtime, its regression test and corresponding state/changelog entries while preserving historical PR #113 validation records and scientific authority.",
+  "rollback_plan": "Close the pull request without merge if synthetic fixtures are nondeterministic, bass or edit-boundary fixtures become sparse hits, outputs lose hypothesis labeling, protected files enter the diff or required tests fail. After merge, revert the detector, its test suite, candidate document and corresponding state/changelog entries together while preserving canonical experiments and all historical failures.",
   "control_report_path": "ai/control-report.md",
   "gate_change": false
 }

--- a/docs/SPARSE_HIT_DETECTOR_CANDIDATE.md
+++ b/docs/SPARSE_HIT_DETECTOR_CANDIDATE.md
@@ -1,0 +1,104 @@
+# Sparse-Hit Detector Candidate v0.1
+
+Status: **SYNTHETIC FIXTURE CANDIDATE / HYPOTHESIS**  
+Implementation: `research/sparse_hit_detector.py`  
+Tracking issue: #128
+
+## Purpose
+
+The candidate proposes sparse cinematic drum-hit events while rejecting sustained bass and low-synth attacks. It is intentionally fail closed: an event that lacks sufficient signal evidence is reported as `UNRESOLVED_TRANSIENT`, not assigned a plausible kick label.
+
+## Non-claims
+
+This is not:
+
+- a trained instrument classifier;
+- validated on private FTC source audio;
+- evidence that a detected event is a kick, drum or specific production layer;
+- a replacement for human listening adjudication;
+- a canonical downstream prior.
+
+`SPARSE_HIT` means only that the declared candidate features passed on the tested signal and parameter set.
+
+## Candidate pipeline
+
+1. Convert declared mono or channel data to mono for the candidate analysis.
+2. Frame the signal and calculate positive spectral flux.
+3. Produce onset proposals against a rolling robust baseline.
+4. Apply a refractory interval to avoid repeated proposals from one decay.
+5. Measure attack spectral power in four declared bands:
+   - low: 20–180 Hz;
+   - low-mid: 180–700 Hz;
+   - upper-mid: 700–5000 Hz;
+   - high: 5000–20000 Hz.
+6. Measure attack spectral flatness and the 80–160 ms persistence ratio relative to the first 30 ms.
+7. Classify using declared thresholds.
+
+## Fail-closed classes
+
+- `SPARSE_HIT` — broadband, sufficiently flat transient attack with limited persistence.
+- `BASS_ATTACK` — low/low-mid-dominant, harmonically concentrated and persistent event.
+- `UNRESOLVED_TRANSIENT` — onset evidence exists but neither declared class is adequately supported.
+- `NO_EVENT` — attack energy does not meet the minimum event threshold.
+
+## Output contract
+
+Each candidate includes:
+
+- integer sample index;
+- seconds derived from the declared sample rate;
+- robust onset score;
+- four band-power shares;
+- number of active bands;
+- spectral flatness;
+- persistence ratio;
+- confidence;
+- classification;
+- detector version;
+- parameter hash;
+- evidence class `HYPOTHESIS`.
+
+## Initial synthetic fixtures
+
+The unit suite contains deterministic fixtures for:
+
+- sparse kick with a broadband click;
+- cinematic low hit with a broadband crack;
+- sustained bass pluck;
+- low synth stab;
+- edit boundary;
+- stereo input;
+- parameter-hash mutation.
+
+Acceptance boundaries:
+
+- bass and synth fixtures must not become `SPARSE_HIT`;
+- edit boundaries must fail closed;
+- true synthetic hit candidates must be located near the inserted sample;
+- every configuration change must alter the parameter hash.
+
+## Known limitations
+
+- Thresholds are fixture-informed and have not been calibrated on a representative public corpus.
+- Mono reduction can discard channel-specific transient evidence.
+- Spectral flatness and persistence are not unique to percussion.
+- Confidence is a transparent heuristic, not a probability estimate.
+- Sample-rate generality is declared but only the 48 kHz synthetic fixture set is currently tested.
+- No precision, recall or confusion matrix is claimed beyond the included fixtures.
+
+## Promotion requirements
+
+Before any real-source promotion:
+
+1. preserve the exact input digest and detector parameter hash;
+2. run a broader synthetic and public-domain fixture matrix;
+3. report all false positives and false negatives;
+4. conduct human listening adjudication on candidate windows;
+5. keep `UNRESOLVED_TRANSIENT` where instrument identity remains ambiguous;
+6. review whether the candidate is useful as an exploratory prior without turning it into authority.
+
+Successful future tests do not erase failures from this candidate version.
+
+## Rollback
+
+Revert the candidate implementation, tests and this document if the feature contract is misleading or the fixture behavior is not reproducible. Do not rewrite a failed candidate as validated evidence.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -54,8 +54,18 @@ Scientific authority remains unchanged: canonical offline evidence and the Pytho
 - The restored surface includes the static HTML/CSS/JavaScript runtime, example session and local run instructions.
 - Current regression tests verify file presence, asset wiring, preview-only evidence labels, JSON parseability and sample-addressed session-contract structure.
 - The restoration deliberately excludes the mirror PR's protected schemas, validators and workflow edits so this change remains `R1_SAFE_UI`.
-- Historical mirror status remains `STRUCTURE_AND_EXCHANGE_CI_VERIFIED`; the current restoration must pass its own AI Gate and Reference CI before merge.
+- Historical mirror status remains `STRUCTURE_AND_EXCHANGE_CI_VERIFIED`; the current restoration passed its own Reference CI before merge through PR #127.
 - Auditory QA, Android/mobile interaction QA, browser timing determinism, Rust/WASM parity and Three.js validation remain open. Restoring the runtime does not promote any of those claims.
+
+## Sparse-hit detector candidate
+
+- `research/sparse_hit_detector.py` defines candidate v0.1 for synthetic-only sparse transient research.
+- The candidate uses robust spectral-flux onset proposals, four-band attack power, attack spectral flatness, an 80–160 ms persistence ratio and a refractory interval.
+- Classes are `SPARSE_HIT`, `BASS_ATTACK`, `UNRESOLVED_TRANSIENT` and `NO_EVENT`; ambiguity fails closed rather than becoming a plausible instrument label.
+- Every result retains integer sample index, derived seconds, feature values, confidence, detector version, parameter hash and evidence class `HYPOTHESIS`.
+- `tests/test_sparse_hit_detector.py` contains seven deterministic synthetic checks for two hit fixtures, bass rejection, synth rejection, edit-boundary rejection, stereo input and parameter-hash changes.
+- Local development execution passed all seven candidate tests before publication. Repository unit tests, reference experiment and public-boundary checks remain required on the exact PR head.
+- No FTC audio, private source material, precision/recall claim or real-instrument authority is included. Human listening and broader fixture validation remain mandatory before promotion.
 
 ## Remaining external platform enforcement
 
@@ -66,8 +76,8 @@ Scientific authority remains unchanged: canonical offline evidence and the Pytho
 
 ## Documentation state
 
-The activation history, live-test evidence, operating procedure, collaboration-provenance policy, browser/WASM parity protocol, visualization-semantics contract, restored Preview Lab runtime and remaining external-control gaps are recorded using durable wording. No gate implementation, protected schema, scientific baseline, deployment behavior or evidence-classification rule is changed by the safe-UI restoration.
+The activation history, live-test evidence, operating procedure, collaboration-provenance policy, browser/WASM parity protocol, visualization-semantics contract, restored Preview Lab runtime, sparse-hit candidate and remaining external-control gaps are recorded using durable wording. The detector remains a hypothesis and does not alter canonical scenarios, reference outputs or verified DSP scope.
 
 ## Rollback
 
-If a factual error is discovered, revert only the relevant documentation or Preview Lab restoration commit. Preserve the active gate implementation, activation commit, live-test provenance, Reference CI scientific authority and publication boundary. Reverting the runtime must not delete historical validation records or promote an unverified browser claim.
+If a factual or implementation error is discovered, revert the sparse-hit candidate, its tests and documentation together. Preserve the active gate implementation, activation commit, live-test provenance, Reference CI scientific authority, Preview Lab history and publication boundary. A failed candidate must not be rewritten as validated evidence.

--- a/research/sparse_hit_detector.py
+++ b/research/sparse_hit_detector.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+import json
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+
+CLASS_SPARSE_HIT = "SPARSE_HIT"
+CLASS_BASS_ATTACK = "BASS_ATTACK"
+CLASS_UNRESOLVED = "UNRESOLVED_TRANSIENT"
+CLASS_NO_EVENT = "NO_EVENT"
+
+_BANDS_HZ = (
+    ("low", 20.0, 180.0),
+    ("low_mid", 180.0, 700.0),
+    ("upper_mid", 700.0, 5000.0),
+    ("high", 5000.0, 20000.0),
+)
+
+
+@dataclass(frozen=True)
+class DetectorConfig:
+    sample_rate_hz: int = 48000
+    frame_size: int = 1024
+    hop_size: int = 128
+    onset_z_threshold: float = 6.0
+    refractory_ms: float = 350.0
+    min_attack_rms: float = 1e-4
+    min_sparse_flatness: float = 0.10
+    min_sparse_broadband_share: float = 0.003
+    max_sparse_persistence_ratio: float = 0.65
+    max_bass_flatness: float = 0.01
+    min_bass_persistence_ratio: float = 0.45
+    min_bass_low_share: float = 0.90
+    active_band_share: float = 0.001
+
+    def validate(self) -> None:
+        if self.sample_rate_hz < 8000:
+            raise ValueError("sample_rate_hz must be at least 8000")
+        if self.frame_size < 128 or self.frame_size & (self.frame_size - 1):
+            raise ValueError("frame_size must be a power of two >= 128")
+        if not 1 <= self.hop_size <= self.frame_size:
+            raise ValueError("hop_size must be inside [1, frame_size]")
+        if self.refractory_ms <= 0:
+            raise ValueError("refractory_ms must be positive")
+
+    def parameter_hash(self) -> str:
+        payload = json.dumps(asdict(self), sort_keys=True, separators=(",", ":"))
+        return sha256(payload.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class Candidate:
+    sample_index: int
+    seconds: float
+    onset_z: float
+    low_share: float
+    low_mid_share: float
+    upper_mid_share: float
+    high_share: float
+    broadband_bands: int
+    spectral_flatness: float
+    persistence_ratio: float
+    confidence: float
+    classification: str
+    detector_version: str = "0.1.0-candidate"
+    evidence_class: str = "HYPOTHESIS"
+    parameter_hash: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def _as_mono(signal: np.ndarray | Iterable[float]) -> np.ndarray:
+    data = np.asarray(signal, dtype=np.float64)
+    if data.ndim == 1:
+        return data
+    if data.ndim != 2:
+        raise ValueError("signal must be mono or two-dimensional channel data")
+    if data.shape[0] <= 8 and data.shape[1] > data.shape[0]:
+        return data.mean(axis=0)
+    return data.mean(axis=1)
+
+
+def _frame_signal(signal: np.ndarray, frame_size: int, hop_size: int) -> np.ndarray:
+    if signal.size < frame_size:
+        return np.empty((0, frame_size), dtype=np.float64)
+    view = np.lib.stride_tricks.sliding_window_view(signal, frame_size)
+    return view[::hop_size]
+
+
+def _robust_onset_z(total_flux: np.ndarray, history_frames: int) -> np.ndarray:
+    transformed = np.log1p(total_flux)
+    scores = np.zeros_like(transformed)
+    for index, value in enumerate(transformed):
+        start = max(0, index - history_frames)
+        history = transformed[start:index]
+        if history.size < 8:
+            stop = min(transformed.size, max(8, history_frames))
+            history = transformed[:stop]
+        baseline = float(np.median(history))
+        mad = float(np.median(np.abs(history - baseline)))
+        scale = max(1.4826 * mad, 0.05, abs(baseline) * 0.05)
+        scores[index] = (value - baseline) / scale
+    return scores
+
+
+def _candidate_peak_indices(scores: np.ndarray, threshold: float, refractory_frames: int) -> list[int]:
+    peaks: list[int] = []
+    for index in range(1, scores.size - 1):
+        if scores[index] < threshold:
+            continue
+        if scores[index] < scores[index - 1] or scores[index] < scores[index + 1]:
+            continue
+        if peaks and index - peaks[-1] < refractory_frames:
+            if scores[index] > scores[peaks[-1]]:
+                peaks[-1] = index
+            continue
+        peaks.append(index)
+    return peaks
+
+
+def _rms(values: np.ndarray) -> float:
+    if values.size == 0:
+        return 0.0
+    return float(np.sqrt(np.mean(np.square(values, dtype=np.float64))))
+
+
+def _attack_spectrum_features(
+    signal: np.ndarray,
+    sample_index: int,
+    config: DetectorConfig,
+) -> tuple[np.ndarray, float]:
+    size = config.frame_size * 2
+    segment = np.zeros(size, dtype=np.float64)
+    available = min(size, max(0, signal.size - sample_index))
+    if available:
+        segment[:available] = signal[sample_index : sample_index + available]
+    window = np.hanning(size)
+    magnitude = np.abs(np.fft.rfft(segment * window)) + 1e-12
+    frequencies = np.fft.rfftfreq(size, 1.0 / config.sample_rate_hz)
+
+    powers: list[float] = []
+    for _, low_hz, high_hz in _BANDS_HZ:
+        mask = (frequencies >= low_hz) & (frequencies < high_hz)
+        powers.append(float(np.square(magnitude[mask]).sum()))
+    power = np.asarray(powers, dtype=np.float64)
+    shares = power / max(float(power.sum()), 1e-12)
+
+    audible = (frequencies >= 20.0) & (frequencies < min(20000.0, config.sample_rate_hz / 2))
+    audible_magnitude = magnitude[audible]
+    flatness = float(
+        np.exp(np.mean(np.log(audible_magnitude)))
+        / max(float(np.mean(audible_magnitude)), 1e-12)
+    )
+    return shares, flatness
+
+
+def _classify(
+    attack_rms: float,
+    shares: np.ndarray,
+    flatness: float,
+    persistence_ratio: float,
+    onset_z: float,
+    config: DetectorConfig,
+) -> tuple[str, float]:
+    low_share, low_mid_share, upper_mid_share, high_share = map(float, shares)
+    broadband_share = upper_mid_share + high_share
+    active_bands = int(np.sum(shares >= config.active_band_share))
+
+    if attack_rms < config.min_attack_rms:
+        return CLASS_NO_EVENT, 0.0
+
+    if (
+        active_bands >= 3
+        and flatness >= config.min_sparse_flatness
+        and broadband_share >= config.min_sparse_broadband_share
+        and persistence_ratio <= config.max_sparse_persistence_ratio
+    ):
+        confidence = (
+            0.25 * min(active_bands / 4.0, 1.0)
+            + 0.30 * min(flatness / 0.5, 1.0)
+            + 0.25 * max(0.0, 1.0 - persistence_ratio)
+            + 0.20 * min(max(onset_z, 0.0) / 20.0, 1.0)
+        )
+        return CLASS_SPARSE_HIT, float(min(confidence, 1.0))
+
+    if (
+        low_share + low_mid_share >= config.min_bass_low_share
+        and flatness <= config.max_bass_flatness
+        and persistence_ratio >= config.min_bass_persistence_ratio
+    ):
+        confidence = (
+            0.45 * min(low_share + low_mid_share, 1.0)
+            + 0.30 * min(persistence_ratio, 1.0)
+            + 0.25 * max(0.0, 1.0 - flatness / config.max_bass_flatness)
+        )
+        return CLASS_BASS_ATTACK, float(min(confidence, 1.0))
+
+    return CLASS_UNRESOLVED, float(min(0.80, 0.40 + max(onset_z, 0.0) / 100.0))
+
+
+def detect_sparse_hits(
+    signal: np.ndarray | Iterable[float],
+    config: DetectorConfig | None = None,
+) -> list[Candidate]:
+    """Return fail-closed transient candidates from synthetic or public PCM data.
+
+    This candidate detector is not a trained classifier and does not establish
+    instrument identity. `SPARSE_HIT` is a hypothesis requiring fixture and
+    human/source validation before promotion.
+    """
+
+    active_config = config or DetectorConfig()
+    active_config.validate()
+    mono = _as_mono(signal)
+    if mono.size < active_config.frame_size * 3:
+        return []
+
+    frames = _frame_signal(mono, active_config.frame_size, active_config.hop_size)
+    window = np.hanning(active_config.frame_size)
+    magnitude = np.abs(np.fft.rfft(frames * window, axis=1)) + 1e-12
+    frequencies = np.fft.rfftfreq(active_config.frame_size, 1.0 / active_config.sample_rate_hz)
+    positive_flux = np.maximum(magnitude[1:] - magnitude[:-1], 0.0)
+
+    band_flux: list[np.ndarray] = []
+    for _, low_hz, high_hz in _BANDS_HZ:
+        mask = (frequencies >= low_hz) & (frequencies < high_hz)
+        band_flux.append(positive_flux[:, mask].sum(axis=1))
+    total_flux = np.stack(band_flux, axis=1).sum(axis=1)
+
+    history_frames = max(8, int(0.5 * active_config.sample_rate_hz / active_config.hop_size))
+    onset_scores = _robust_onset_z(total_flux, history_frames)
+    refractory_frames = max(
+        1,
+        int(
+            active_config.refractory_ms
+            * active_config.sample_rate_hz
+            / 1000.0
+            / active_config.hop_size
+        ),
+    )
+    peaks = _candidate_peak_indices(
+        onset_scores,
+        active_config.onset_z_threshold,
+        refractory_frames,
+    )
+
+    parameter_hash = active_config.parameter_hash()
+    results: list[Candidate] = []
+    for peak in peaks:
+        sample_index = (peak + 1) * active_config.hop_size
+        attack_stop = min(mono.size, sample_index + int(0.030 * active_config.sample_rate_hz))
+        persistence_start = min(
+            mono.size,
+            sample_index + int(0.080 * active_config.sample_rate_hz),
+        )
+        persistence_stop = min(
+            mono.size,
+            sample_index + int(0.160 * active_config.sample_rate_hz),
+        )
+        attack_rms = _rms(mono[sample_index:attack_stop])
+        persistence_rms = _rms(mono[persistence_start:persistence_stop])
+        persistence_ratio = persistence_rms / max(attack_rms, 1e-12)
+
+        shares, flatness = _attack_spectrum_features(mono, sample_index, active_config)
+        classification, confidence = _classify(
+            attack_rms,
+            shares,
+            flatness,
+            persistence_ratio,
+            float(onset_scores[peak]),
+            active_config,
+        )
+
+        results.append(
+            Candidate(
+                sample_index=sample_index,
+                seconds=sample_index / active_config.sample_rate_hz,
+                onset_z=float(onset_scores[peak]),
+                low_share=float(shares[0]),
+                low_mid_share=float(shares[1]),
+                upper_mid_share=float(shares[2]),
+                high_share=float(shares[3]),
+                broadband_bands=int(np.sum(shares >= active_config.active_band_share)),
+                spectral_flatness=flatness,
+                persistence_ratio=float(persistence_ratio),
+                confidence=confidence,
+                classification=classification,
+                parameter_hash=parameter_hash,
+            )
+        )
+    return results
+
+
+def write_report(candidates: Iterable[Candidate], destination: str | Path) -> None:
+    payload = {
+        "detector_version": "0.1.0-candidate",
+        "evidence_class": "HYPOTHESIS",
+        "candidates": [candidate.to_dict() for candidate in candidates],
+    }
+    Path(destination).write_text(
+        json.dumps(payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )

--- a/tests/test_sparse_hit_detector.py
+++ b/tests/test_sparse_hit_detector.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "sparse_hit_detector",
+    ROOT / "research" / "sparse_hit_detector.py",
+)
+detector = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = detector
+assert SPEC.loader
+SPEC.loader.exec_module(detector)
+
+
+SAMPLE_RATE = 48000
+EVENT_SAMPLE = int(0.25 * SAMPLE_RATE)
+
+
+def _decaying_sine(
+    frequency_hz: float,
+    duration_s: float,
+    amplitude: float,
+    tau_s: float,
+) -> np.ndarray:
+    signal = np.zeros(SAMPLE_RATE, dtype=np.float64)
+    length = int(duration_s * SAMPLE_RATE)
+    time = np.arange(length) / SAMPLE_RATE
+    signal[EVENT_SAMPLE : EVENT_SAMPLE + length] = (
+        amplitude * np.sin(2 * np.pi * frequency_hz * time) * np.exp(-time / tau_s)
+    )
+    return signal
+
+
+def _noise_burst(duration_s: float, amplitude: float, seed: int) -> np.ndarray:
+    signal = np.zeros(SAMPLE_RATE, dtype=np.float64)
+    length = int(duration_s * SAMPLE_RATE)
+    rng = np.random.default_rng(seed)
+    signal[EVENT_SAMPLE : EVENT_SAMPLE + length] = (
+        rng.normal(0.0, amplitude, length) * np.hanning(length)
+    )
+    return signal
+
+
+def sparse_kick() -> np.ndarray:
+    return _decaying_sine(65.0, 0.30, 0.90, 0.07) + _noise_burst(0.012, 0.35, 2)
+
+
+def cinematic_hit() -> np.ndarray:
+    return _decaying_sine(48.0, 0.50, 0.90, 0.12) + _noise_burst(0.025, 0.60, 3)
+
+
+def bass_pluck() -> np.ndarray:
+    signal = np.zeros(SAMPLE_RATE, dtype=np.float64)
+    length = int(0.50 * SAMPLE_RATE)
+    time = np.arange(length) / SAMPLE_RATE
+    envelope = (1.0 - np.exp(-time / 0.008)) * np.exp(-time / 0.35)
+    harmonics = (
+        np.sin(2 * np.pi * 82.4 * time)
+        + 0.35 * np.sin(2 * np.pi * 164.8 * time)
+        + 0.15 * np.sin(2 * np.pi * 247.2 * time)
+    )
+    signal[EVENT_SAMPLE : EVENT_SAMPLE + length] = 0.50 * envelope * harmonics
+    return signal
+
+
+def low_synth_stab() -> np.ndarray:
+    signal = np.zeros(SAMPLE_RATE, dtype=np.float64)
+    length = int(0.40 * SAMPLE_RATE)
+    time = np.arange(length) / SAMPLE_RATE
+    envelope = np.minimum(time / 0.015, 1.0) * np.exp(-time / 0.30)
+    signal[EVENT_SAMPLE : EVENT_SAMPLE + length] = 0.40 * envelope * (
+        np.sin(2 * np.pi * 110.0 * time)
+        + 0.50 * np.sin(2 * np.pi * 220.0 * time)
+    )
+    return signal
+
+
+def edit_boundary() -> np.ndarray:
+    signal = np.zeros(SAMPLE_RATE, dtype=np.float64)
+    signal[EVENT_SAMPLE:] = 0.20
+    return signal
+
+
+def first_candidate(signal: np.ndarray):
+    candidates = detector.detect_sparse_hits(signal)
+    if not candidates:
+        raise AssertionError("Expected at least one transient candidate")
+    return candidates[0]
+
+
+class SparseHitDetectorTests(unittest.TestCase):
+    def test_sparse_kick_is_candidate_hit(self) -> None:
+        candidate = first_candidate(sparse_kick())
+        self.assertEqual(detector.CLASS_SPARSE_HIT, candidate.classification)
+        self.assertLess(
+            abs(candidate.sample_index - EVENT_SAMPLE),
+            int(0.03 * SAMPLE_RATE),
+        )
+        self.assertEqual("HYPOTHESIS", candidate.evidence_class)
+
+    def test_cinematic_hit_is_candidate_hit(self) -> None:
+        candidate = first_candidate(cinematic_hit())
+        self.assertEqual(detector.CLASS_SPARSE_HIT, candidate.classification)
+        self.assertGreaterEqual(candidate.broadband_bands, 3)
+
+    def test_bass_pluck_is_not_sparse_hit(self) -> None:
+        candidate = first_candidate(bass_pluck())
+        self.assertEqual(detector.CLASS_BASS_ATTACK, candidate.classification)
+
+    def test_low_synth_is_not_sparse_hit(self) -> None:
+        candidate = first_candidate(low_synth_stab())
+        self.assertNotEqual(detector.CLASS_SPARSE_HIT, candidate.classification)
+
+    def test_edit_boundary_fails_closed(self) -> None:
+        candidate = first_candidate(edit_boundary())
+        self.assertEqual(detector.CLASS_UNRESOLVED, candidate.classification)
+
+    def test_parameter_hash_changes_with_configuration(self) -> None:
+        default_hash = detector.DetectorConfig().parameter_hash()
+        changed_hash = detector.DetectorConfig(min_sparse_flatness=0.2).parameter_hash()
+        self.assertNotEqual(default_hash, changed_hash)
+
+    def test_stereo_input_is_supported(self) -> None:
+        mono = sparse_kick()
+        stereo = np.stack([mono, mono], axis=0)
+        candidate = first_candidate(stereo)
+        self.assertEqual(detector.CLASS_SPARSE_HIT, candidate.classification)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds sparse-hit detector candidate v0.1 as a deterministic, synthetic-only and fail-closed research implementation.

## Implementation

- robust spectral-flux onset proposals;
- four-band attack-power features;
- attack spectral flatness;
- attack-to-persistence ratio;
- refractory suppression of repeated decay candidates;
- transparent heuristic confidence;
- versioned configuration hash;
- machine-readable candidate reports.

## Fail-closed classes

- `SPARSE_HIT`
- `BASS_ATTACK`
- `UNRESOLVED_TRANSIENT`
- `NO_EVENT`

Every output remains evidence class `HYPOTHESIS`.

## Synthetic fixtures

Seven deterministic tests cover:

- sparse kick candidate;
- cinematic low-hit candidate;
- bass-pluck rejection;
- low-synth rejection;
- edit-boundary fail-closed behavior;
- stereo input;
- parameter-hash mutation.

## Scientific boundary

- no private or copyrighted source audio;
- no real-instrument identification claim;
- no precision/recall claim beyond the included fixtures;
- no canonical scenario, reference output or Rust-core change;
- human listening and broader fixture validation remain mandatory before real-source promotion.

## Scope

- `research/sparse_hit_detector.py`
- `tests/test_sparse_hit_detector.py`
- `docs/SPARSE_HIT_DETECTOR_CANDIDATE.md`
- `CHANGELOG.md`
- `docs/STATE.md`
- required proof/report artifacts

## Risk and tests

- risk class: `R3_DSP_OR_SCIENCE`
- required tests: `unit_tests`, `reference_experiment`, `public_boundary`
- merge only after required checks pass on the exact head

Closes #128 after CI and exact-head review.

## Rollback

Revert the detector, tests, candidate document and corresponding state/changelog entries together. Preserve canonical experiments and all candidate failure provenance.