### PR TITLE
Add isolated audio deconstruction experiment trio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
 - Keep schema/workflow restoration outside this safe-UI scope; auditory, mobile and deterministic-browser validation remain open gates.
 - Add sparse-hit detector candidate v0.1 with robust onset proposals, broadband/flatness/persistence features, fail-closed classifications, versioned parameters and machine-readable candidate reports.
 - Add seven deterministic synthetic fixture tests covering sparse hits, bass rejection, low-synth rejection, edit-boundary handling, stereo input and parameter-hash mutation; all outputs remain `HYPOTHESIS` pending human/source validation.
+- Add three isolated audio-deconstruction experiment candidates with independent fixtures, pipelines, JSON recipes, generated reports and regression tests: `EXP-HARMONIC-RECOVERY-001`, `EXP-LOWBAND-COLLISION-001` and `EXP-STEREO-TOMOGRAPHY-001`.
+- Preserve separate scientific gates: harmonic reconstruction versus parameter recovery, kick/bass event precision-recall with bass-only negative controls, and stereo component closure/delay recovery before instrument semantics.
+- Record initial development failures instead of erasing them: edge fades contaminated the harmonic null metric, and a first stereo delay calculation compared algebraically identical Mid/Side signals; both implementations were corrected before the published candidate run.
+- Local candidate execution passed ten new deterministic tests. Generated baseline reports remain `HYPOTHESIS`; the low-band coincident kick/bass case deliberately remains unresolved rather than being mislabeled.
 
 Remaining external enforcement work:
 

--- a/ai/control-report.md
+++ b/ai/control-report.md
@@ -1,90 +1,114 @@
 # AI Gate Control Report
 
-Task ID: `SPARSE_HIT_DETECTOR_V0_1_20260712`  
-Branch: `research/sparse-hit-detector-v0-1-20260712`  
-Base commit: `0c100a6399a2fb1d07653cd6c4eff9e12e23957a`
+Task ID: `AUDIO_DECONSTRUCTION_EXPERIMENT_TRIO_20260712`  
+Branch: `research/audio-deconstruction-experiment-trio-20260712`  
+Base commit: `e967f68e3635887cb6f0a99081662e487064c7d3`
 
 ## Project purpose
 
-NullForge separates exploratory DSP hypotheses from canonical measured evidence. A useful detector must expose its feature contract, parameter set, failure classes and limitations rather than converting low-frequency transients into confident instrument labels.
+NullForge seeks reproducible evidence about what source information can be recovered from audio. This task must convert three research proposals into independently executable, falsifiable candidates without merging their evidence, fixtures or failure states.
 
 ## Current task
 
-Publish sparse-hit detector candidate v0.1 using only deterministic synthetic fixtures. The candidate proposes broadband sparse transients, rejects sustained bass-like attacks, fails ambiguous edit boundaries closed, hashes its configuration and labels every output `HYPOTHESIS`.
+Publish three isolated experiment packages:
+
+1. `EXP-HARMONIC-RECOVERY-001` — blind F0 and harmonic-body recovery;
+2. `EXP-LOWBAND-COLLISION-001` — kick/bass collision discrimination;
+3. `EXP-STEREO-TOMOGRAPHY-001` — spatial decomposition and delay recovery.
+
+Each package owns its pipeline, synthetic fixture generator, recipe, output report and tests. A result from one experiment cannot promote or rescue another.
 
 ## Mandatory files read
 
-All ten files configured by `docs/governance/AI_GATE_CONFIG.json` were read or verified against `main@0c100a6399a2fb1d07653cd6c4eff9e12e23957a`. Current base hashes were recorded before editing. The scientific-integrity policy and repository architecture were treated as binding: the detector cannot alter canonical scenarios, reference outputs or previously verified DSP scope.
+All ten mandatory files configured by `docs/governance/AI_GATE_CONFIG.json` were read or verified against `main@e967f68e3635887cb6f0a99081662e487064c7d3`. The scientific-integrity rules were treated as binding: the analysis stage receives observed signal only, evaluator ground truth remains separate, reconstruction and parameter recovery are scored independently, and failures remain in provenance.
 
 ## What absolutely must not be changed
 
-This task must not modify AI Gate, Reference CI, protected schemas, scenarios, reference runners, Rust core, deployment, Preview Lab behavior or external rules. It must not include private audio, FTC source material, copied commercial recordings or claims of real-instrument validation. It must not promote confidence as probability or `SPARSE_HIT` as instrument identity.
+This task must not modify AI Gate, Reference CI, protected schemas, canonical scenarios, reference outputs, Rust core, Preview Lab runtime, deployment, external rules, private source audio or internal platform identifiers. It must not claim real-source accuracy, plugin identity or validated instrument separation.
 
 ## Latest stable / green version
 
-The branch starts from `main@0c100a6399a2fb1d07653cd6c4eff9e12e23957a`, the merge commit for PR #127 and the current green Preview Lab restoration baseline.
+The branch starts from `main@e967f68e3635887cb6f0a99081662e487064c7d3`, the merge commit for sparse-hit candidate PR #129.
 
 ## Approved scope
 
 The task is limited to:
 
-- `research/sparse_hit_detector.py`;
-- `tests/test_sparse_hit_detector.py`;
-- `docs/SPARSE_HIT_DETECTOR_CANDIDATE.md`;
+- `research/experiments/EXP-HARMONIC-RECOVERY-001/**`;
+- `research/experiments/EXP-LOWBAND-COLLISION-001/**`;
+- `research/experiments/EXP-STEREO-TOMOGRAPHY-001/**`;
+- three dedicated `tests/test_exp_*.py` files;
+- three generated synthetic baseline reports under `artifacts/`;
+- `docs/AUDIO_DECONSTRUCTION_EXPERIMENT_TRIO.md`;
 - substantive `CHANGELOG.md` and `docs/STATE.md` updates.
 
-The required proof and control report are always-allowed task artifacts. No protected path may enter the diff.
+The proof and this report are always-allowed task artifacts.
 
-## Candidate design
+## Pipeline isolation
 
-The proposal stage calculates positive spectral flux in four declared frequency regions and compares total flux against a rolling robust baseline. A refractory interval suppresses multiple proposals from one decay.
+- No experiment imports another experiment.
+- No experiment writes shared mutable state.
+- Each experiment has a unique ID, recipe, output path and result schema.
+- Each experiment can pass, fail, be reverted or be superseded without changing another experiment's evidence class.
 
-For each proposal, the detector records:
+## Candidate results
 
-- integer sample index and seconds derived from the declared sample rate;
-- low, low-mid, upper-mid and high attack-power shares;
-- number of active bands;
-- attack spectral flatness;
-- 80–160 ms persistence relative to the first 30 ms;
-- transparent heuristic confidence;
-- class, detector version, parameter hash and evidence class.
+### EXP-HARMONIC-RECOVERY-001
 
-The class boundary is explicit:
+- Clean harmonic body: estimated F0 `109.9998739 Hz`, error `−0.00199 cent`, partial MAE `1.30e-6`, null depth `−63.30 dB`.
+- Noisy harmonic body: null depth `−29.29 dB`, residual classified primarily inter-harmonic, reconstruction and parameter gates pass.
+- Soft-clipped body: parameter gate passes but reconstruction remains `REVIEW` at `−21.58 dB`, correctly separating equivalent parameter estimation from incomplete signal reconstruction.
 
-- `SPARSE_HIT` requires broadband attack evidence, sufficient flatness and limited persistence;
-- `BASS_ATTACK` requires low/low-mid dominance, spectral concentration and persistence;
-- `UNRESOLVED_TRANSIENT` preserves ambiguous proposals;
-- `NO_EVENT` rejects insufficient attack energy.
+### EXP-LOWBAND-COLLISION-001
 
-## Synthetic fixture evidence
+- Aggregate synthetic precision `1.0`, recall `0.667`, F1 `0.8`.
+- Kick-only and ±20 ms offset cases pass.
+- Bass-only creates zero false kick candidates.
+- Exact kick/bass coincidence produces unresolved candidates and two false negatives rather than false instrument certainty.
 
-Seven deterministic local tests passed before publication:
+### EXP-STEREO-TOMOGRAPHY-001
 
-1. sparse kick with broadband click → `SPARSE_HIT` near the inserted sample;
-2. cinematic low hit with broadband crack → `SPARSE_HIT` with at least three active bands;
-3. sustained bass pluck → `BASS_ATTACK`;
-4. low synth stab → not `SPARSE_HIT`;
-5. edit boundary → `UNRESOLVED_TRANSIENT`;
-6. parameter mutation → different parameter hash;
-7. identical stereo input → supported and classified consistently.
+- Mid/Side roundtrip closure is below `−286 dB` in all baseline fixtures.
+- Zero-delay center and side components correlate at approximately `1.0` with truth.
+- A 17-sample right-channel delay is recovered exactly as a `−17` sample alignment.
+- Decorrelated material is classified as `DECORRELATED_FIELD`, not assigned an instrument identity.
 
-These fixtures demonstrate only the implemented contract on those synthetic signals. They do not establish population precision, recall or real-source validity.
+All results retain evidence class `HYPOTHESIS`.
+
+## Preserved failed attempts
+
+Two failures occurred during implementation and are retained because they changed the method:
+
+1. The first harmonic fixture used 10 ms edge fades while the fitting model omitted the envelope. The residual was dominated by deterministic edge mismatch and the clean null stalled around `−23.15 dB`. Correction: the baseline fixture now measures an unwindowed stationary signal; future edge-window experiments must either model the envelope or score only the declared interior.
+2. The first stereo delay estimator compared `L−Mid` against `−(R−Mid)`. These expressions are algebraically identical, so the estimator always preferred zero delay. Correction: isolate the declared side-frequency band directly from L and polarity-corrected R, then estimate lag by FFT correlation.
+
+These are `FAILED_ATTEMPT` records inside this control report, not hidden prehistory.
+
+## Tests run locally
+
+`python -m unittest discover -s tests -v` against the three new test files passed 10/10 checks:
+
+- three harmonic-recovery checks;
+- three low-band collision checks;
+- four stereo-tomography checks.
+
+The exact PR head must still pass full repository unit tests, Reference CI reference experiment and public-boundary validation.
 
 ## Publication-boundary review
 
-The implementation, fixtures and documentation are entirely synthetic and public. They contain no Drive/Notion links, internal IDs, source audio, private project mappings, credentials or raw conversations. The candidate creates no network, filesystem-discovery or model dependency.
+All new audio is generated in memory from deterministic mathematical fixtures. No commercial recording, FTC source, Drive/Notion URL, workspace ID, credential, private actor roster or raw conversation is included.
 
-## Scientific risks and mitigations
+## Scientific risks
 
-- **Fixture overfitting:** thresholds may fit the initial examples. Mitigation: label as candidate, publish thresholds, preserve failures and require a broader matrix before promotion.
-- **False instrument identity:** flatness and persistence are not percussion-specific. Mitigation: `SPARSE_HIT` is a signal hypothesis, not a drum label.
-- **Mono reduction:** channel-specific evidence may be lost. Mitigation: document limitation and retain stereo support only as deterministic reduction, not spatial inference.
-- **Confidence misuse:** heuristic confidence is not calibrated probability. Mitigation: state this explicitly and retain the feature vector.
-- **Threshold drift:** later tuning could silently alter behavior. Mitigation: deterministic parameter hash and versioned candidate status.
+- Thresholds may overfit the small fixture matrices.
+- Harmonic fitting assumes stationary monophonic content and does not yet recover drift.
+- Low-band recall drops to zero for exact kick/bass coincidence; this is an explicit unresolved region.
+- Stereo tomography relies on a declared diagnostic frequency split for delay estimation and does not prove general source separation.
+- Generated reports are baseline observations, not promoted facts about real music.
 
 ## Risk class
 
-`R3_DSP_OR_SCIENCE` is required because the task introduces signal-analysis logic and scientific classification language, even though it does not touch protected reference or scenario paths.
+`R3_DSP_OR_SCIENCE` is required because this task adds DSP logic, evaluation metrics and scientific classification language while leaving protected canonical evidence paths unchanged.
 
 ## Required tests
 
@@ -94,25 +118,23 @@ The fixed R3 profile requires:
 - `reference_experiment`;
 - `public_boundary`.
 
-The reference experiment must remain unchanged and pass independently, proving that the candidate did not contaminate canonical outputs. Reference CI must be green on the exact PR head. AI Gate must validate branch/base binding, hashes, exact scope, state updates and report content.
+A later successful test cannot override a failed preflight, scope mismatch or publication-boundary failure.
 
 ## Promotion boundary
 
-Real-source use remains blocked until all of the following are recorded:
+Promotion beyond synthetic candidate status requires separate experiment-specific evidence:
 
-- exact input and parameter digests;
-- a broader synthetic and public-domain fixture matrix;
-- false-positive and false-negative reporting;
-- human listening adjudication of candidate windows;
-- explicit treatment of unresolved identity;
-- a reviewed decision about whether the candidate is useful as an exploratory prior.
-
-A later pass cannot erase failures from v0.1.
+- a broader hidden fixture matrix;
+- exact input and parameter hashes;
+- real stems or public-domain sources where applicable;
+- precision/recall or recovery-error reporting on held-out material;
+- human listening adjudication;
+- explicit documentation of unresolved regions and model-created artifacts.
 
 ## Rollback plan
 
-Close without merge if fixture behavior, determinism, scope, labeling or required tests fail. After merge, revert the implementation, tests, candidate document and state/changelog entries together. Preserve canonical experiments, Reference CI, prior measurements and failure provenance.
+If any pipeline, report or test is incorrect, revert that experiment folder, its dedicated test and report, then update the trio document, state and changelog additively. Do not rewrite another experiment's status. Preserve this report's failed-attempt record, canonical reference experiments, AI Gate and prior sparse-hit provenance.
 
 ## Agent assertion
 
-This change turns a vague detector idea into a reproducible and falsifiable candidate. It deliberately stops short of claiming that any real production layer has been identified.
+This task turns three proposals into runnable and falsifiable candidates. It does not claim that the candidates have solved source separation; it establishes three clean places where the project can learn without contaminating one experiment with another.

--- a/ai/session-proof.json
+++ b/ai/session-proof.json
@@ -1,14 +1,14 @@
 {
   "schema_version": "0.2.1",
-  "task_id": "SPARSE_HIT_DETECTOR_V0_1_20260712",
-  "branch": "research/sparse-hit-detector-v0-1-20260712",
-  "base_commit": "0c100a6399a2fb1d07653cd6c4eff9e12e23957a",
+  "task_id": "AUDIO_DECONSTRUCTION_EXPERIMENT_TRIO_20260712",
+  "branch": "research/audio-deconstruction-experiment-trio-20260712",
+  "base_commit": "e967f68e3635887cb6f0a99081662e487064c7d3",
   "agent": {
     "name": "ChatGPT",
     "model_or_runtime": "GPT-5.6 Thinking / GitHub connector",
     "operator": "human_project_arbiter"
   },
-  "created_at": "2026-07-12T05:09:00Z",
+  "created_at": "2026-07-12T16:15:49Z",
   "mandatory_files": [
     "AGENTS.md",
     "README.md",
@@ -27,27 +27,40 @@
     "ARCHITECTURE.md": "sha256:d1710e752dac3b992c39d0fb777f7993686bfd5835be433abad6b1b3127904fc",
     "SCIENTIFIC_INTEGRITY.md": "sha256:0e5c9beabb486e761d4f3511dbde8cf726fe8af8365f24b24b87de821eb40bac",
     "PUBLICATION_BOUNDARY.md": "sha256:c5e685a531565fd3bd60bbca3c7c5e32da42d00c6908b388688bb8951fb60ec0",
-    "CHANGELOG.md": "sha256:d96bd3a9f305a15cdc7e5178272eff16f420e108ae8db44c505be7516f47f430",
-    "docs/STATE.md": "sha256:5a7267426f41da60a6ead17f3ec16e726d5482a551edcb84198377cb881cda52",
+    "CHANGELOG.md": "sha256:bab40056e0517807e8f5395af52e74391cd01057f80576454c25886d3afb5fd7",
+    "docs/STATE.md": "sha256:279bc798482f510054c3e245c60b8edaf6eba4244ec75eb23bd578223e94c2d2",
     "docs/governance/AI_GATE_RULESET.md": "sha256:e99e54e5b44c1b05b872589a56132a965029b7cbe43a92334c07e51ba9c1191f",
     "docs/governance/AI_GATE_CONFIG.json": "sha256:31f10fe92713c5003f43fa0dc4e558e56f965406f1c89ddbab1e1e19b41499d7",
     "schemas/ai-session-proof.schema.json": "sha256:f45d2f45e1289de9260e6c34e99998e90a67b06392f75cacd53379c3ff766068"
   },
-  "project_state_summary": "NullForge has AI Gate v0.2.1 PATCH-2 active, Reference CI as scientific authority, browser and visualization contracts, a restored Preview Lab runtime and an internal backlog item for a fail-closed sparse-hit detector.",
-  "current_task_summary": "Publish a deterministic synthetic-only sparse-hit detector candidate with transparent features, parameter hashing, fail-closed classifications, seven fixture tests and explicit hypothesis-level evidence boundaries.",
+  "project_state_summary": "NullForge has AI Gate PATCH-2 active, Reference CI as scientific authority, a restored Preview Lab, a synthetic sparse-hit candidate and no promoted real-source deconstruction claim.",
+  "current_task_summary": "Publish three isolated synthetic audio-deconstruction experiment candidates with independent pipelines, recipes, reports, tests, fail-closed boundaries and preserved failed attempts.",
   "must_not_change": [
-    "AI Gate workflow, validator, configuration, schema, test runner or external ruleset state",
-    "Reference CI authority, canonical scenarios, reference outputs, Rust core or previously verified DSP scope",
-    "private source audio, internal workspace material, unpublished claims or copyrighted fixtures",
-    "Preview Lab runtime behavior, deployment configuration, browser/WASM parity claims or visualization validity"
+    "AI Gate, Reference CI, protected schemas, canonical scenarios, reference outputs or Rust core",
+    "private source audio, internal Drive/Notion identifiers, unpublished client material or credentials",
+    "Preview Lab runtime, deployment configuration, external ruleset state or previously verified DSP scope",
+    "evidence classes of existing experiments or another experiment when one candidate fails"
   ],
-  "latest_green_version": "main@0c100a6399a2fb1d07653cd6c4eff9e12e23957a",
+  "latest_green_version": "main@e967f68e3635887cb6f0a99081662e487064c7d3",
   "allowed_paths": [
     "CHANGELOG.md",
     "docs/STATE.md",
-    "docs/SPARSE_HIT_DETECTOR_CANDIDATE.md",
-    "research/sparse_hit_detector.py",
-    "tests/test_sparse_hit_detector.py"
+    "docs/AUDIO_DECONSTRUCTION_EXPERIMENT_TRIO.md",
+    "research/experiments/EXP-HARMONIC-RECOVERY-001/README.md",
+    "research/experiments/EXP-HARMONIC-RECOVERY-001/pipeline.py",
+    "research/experiments/EXP-HARMONIC-RECOVERY-001/recipe.json",
+    "research/experiments/EXP-LOWBAND-COLLISION-001/README.md",
+    "research/experiments/EXP-LOWBAND-COLLISION-001/pipeline.py",
+    "research/experiments/EXP-LOWBAND-COLLISION-001/recipe.json",
+    "research/experiments/EXP-STEREO-TOMOGRAPHY-001/README.md",
+    "research/experiments/EXP-STEREO-TOMOGRAPHY-001/pipeline.py",
+    "research/experiments/EXP-STEREO-TOMOGRAPHY-001/recipe.json",
+    "tests/test_exp_harmonic_recovery.py",
+    "tests/test_exp_lowband_collision.py",
+    "tests/test_exp_stereo_tomography.py",
+    "artifacts/EXP-HARMONIC-RECOVERY-001/report.json",
+    "artifacts/EXP-LOWBAND-COLLISION-001/report.json",
+    "artifacts/EXP-STEREO-TOMOGRAPHY-001/report.json"
   ],
   "additional_forbidden_paths": [],
   "approved_context_changes": [],
@@ -57,7 +70,7 @@
     "reference_experiment",
     "public_boundary"
   ],
-  "rollback_plan": "Close the pull request without merge if synthetic fixtures are nondeterministic, bass or edit-boundary fixtures become sparse hits, outputs lose hypothesis labeling, protected files enter the diff or required tests fail. After merge, revert the detector, its test suite, candidate document and corresponding state/changelog entries together while preserving canonical experiments and all historical failures.",
+  "rollback_plan": "Revert each failed experiment folder, its dedicated test and generated report independently; update trio documentation, state and changelog additively; preserve failed-attempt provenance, AI Gate, canonical reference experiments and unrelated experiment status.",
   "control_report_path": "ai/control-report.md",
   "gate_change": false
 }

--- a/artifacts/EXP-HARMONIC-RECOVERY-001/report.json
+++ b/artifacts/EXP-HARMONIC-RECOVERY-001/report.json
@@ -1,0 +1,69 @@
+{
+  "claim_boundary": "Synthetic fixtures only; reconstruction is scored separately from parameter recovery.",
+  "evidence_class": "HYPOTHESIS",
+  "experiment_id": "EXP-HARMONIC-RECOVERY-001",
+  "overall_status": "PASS",
+  "pipeline_version": "0.1.0-candidate",
+  "results": [
+    {
+      "estimated_f0_hz": 109.99987387257521,
+      "estimated_partial_amplitudes": [
+        1.0,
+        0.4999991381620671,
+        0.3299986069534706,
+        0.24999816258881893,
+        0.19999882347658404,
+        0.1599974836910499
+      ],
+      "evidence_class": "HYPOTHESIS",
+      "f0_error_cents": -0.0019850565228543052,
+      "fixture_id": "clean_harmonic_body",
+      "harmonic_residual_ratio": 0.9991078127603531,
+      "null_depth_db": -63.30358458304347,
+      "parameter_recovery_score": "PASS",
+      "partial_amplitude_mae": 1.2975213349077548e-06,
+      "pipeline_version": "0.1.0-candidate",
+      "reconstruction_score": "PASS"
+    },
+    {
+      "estimated_f0_hz": 109.99983284296356,
+      "estimated_partial_amplitudes": [
+        1.0,
+        0.49981413551278214,
+        0.329949115420851,
+        0.24984066393466203,
+        0.19990318911747343,
+        0.16009757524756477
+      ],
+      "evidence_class": "HYPOTHESIS",
+      "f0_error_cents": -0.002630801571864858,
+      "fixture_id": "noisy_harmonic_body",
+      "harmonic_residual_ratio": 0.0009208225448896758,
+      "null_depth_db": -29.285122322024492,
+      "parameter_recovery_score": "PASS",
+      "partial_amplitude_mae": 9.841187696603415e-05,
+      "pipeline_version": "0.1.0-candidate",
+      "reconstruction_score": "PASS"
+    },
+    {
+      "estimated_f0_hz": 109.99987384795809,
+      "estimated_partial_amplitudes": [
+        1.0,
+        0.4179885302200444,
+        0.2680327062248893,
+        0.20147501411344626,
+        0.15095823858330962,
+        0.1983889494311702
+      ],
+      "evidence_class": "HYPOTHESIS",
+      "f0_error_cents": -0.001985443959602831,
+      "fixture_id": "soft_clipped_body",
+      "harmonic_residual_ratio": 1.6257084882543157e-05,
+      "null_depth_db": -21.584697194055877,
+      "parameter_recovery_score": "PASS",
+      "partial_amplitude_mae": 0.04665574338158011,
+      "pipeline_version": "0.1.0-candidate",
+      "reconstruction_score": "REVIEW"
+    }
+  ]
+}

--- a/artifacts/EXP-LOWBAND-COLLISION-001/report.json
+++ b/artifacts/EXP-LOWBAND-COLLISION-001/report.json
@@ -1,0 +1,87 @@
+{
+  "aggregate": {
+    "f1": 0.8,
+    "false_negatives": 2,
+    "false_positives": 0,
+    "precision": 1.0,
+    "recall": 0.6666666666666666,
+    "true_positives": 4
+  },
+  "claim_boundary": "Synthetic low-band collisions only; KICK_CANDIDATE is not instrument authority.",
+  "evidence_class": "HYPOTHESIS",
+  "experiment_id": "EXP-LOWBAND-COLLISION-001",
+  "overall_status": "PASS",
+  "pipeline_version": "0.1.0-candidate",
+  "results": [
+    {
+      "f1": 1.0,
+      "false_negatives": 0,
+      "false_positives": 0,
+      "fixture_id": "kick_only",
+      "median_timing_error_ms": 9.0,
+      "precision": 1.0,
+      "predicted_kick_samples": [
+        11520,
+        34176
+      ],
+      "recall": 1.0,
+      "true_kick_samples": [
+        12000,
+        34560
+      ],
+      "true_positives": 2,
+      "unresolved_samples": []
+    },
+    {
+      "f1": 1.0,
+      "false_negatives": 0,
+      "false_positives": 0,
+      "fixture_id": "bass_only",
+      "median_timing_error_ms": null,
+      "precision": 1.0,
+      "predicted_kick_samples": [],
+      "recall": 1.0,
+      "true_kick_samples": [],
+      "true_positives": 0,
+      "unresolved_samples": []
+    },
+    {
+      "f1": 0.0,
+      "false_negatives": 2,
+      "false_positives": 0,
+      "fixture_id": "coincident",
+      "median_timing_error_ms": null,
+      "precision": 0.0,
+      "predicted_kick_samples": [],
+      "recall": 0.0,
+      "true_kick_samples": [
+        12000,
+        34560
+      ],
+      "true_positives": 0,
+      "unresolved_samples": [
+        11520,
+        34176
+      ]
+    },
+    {
+      "f1": 1.0,
+      "false_negatives": 0,
+      "false_positives": 0,
+      "fixture_id": "offset_20ms",
+      "median_timing_error_ms": 4.333333333333333,
+      "precision": 1.0,
+      "predicted_kick_samples": [
+        12032,
+        34176
+      ],
+      "recall": 1.0,
+      "true_kick_samples": [
+        12000,
+        34560
+      ],
+      "true_positives": 2,
+      "unresolved_samples": []
+    }
+  ]
+}

--- a/artifacts/EXP-STEREO-TOMOGRAPHY-001/report.json
+++ b/artifacts/EXP-STEREO-TOMOGRAPHY-001/report.json
@@ -1,0 +1,42 @@
+{
+  "claim_boundary": "Spatial components are classified before any instrument semantics are assigned.",
+  "evidence_class": "HYPOTHESIS",
+  "experiment_id": "EXP-STEREO-TOMOGRAPHY-001",
+  "overall_status": "PASS",
+  "pipeline_version": "0.1.0-candidate",
+  "results": [
+    {
+      "center_correlation": 1.0,
+      "classification": "SIDE_LEVEL_OR_POLARITY_DIFFERENTIAL",
+      "delay_error_samples": 0,
+      "estimated_delay_samples": 0,
+      "evidence_class": "HYPOTHESIS",
+      "fixture_id": "center_plus_side",
+      "lr_correlation": 0.22922546252769535,
+      "reconstruction_error_db": -288.5357025937556,
+      "side_correlation": 1.0000000000000002
+    },
+    {
+      "center_correlation": 0.9761917594475056,
+      "classification": "SIDE_TIME_DIFFERENTIAL",
+      "delay_error_samples": 0,
+      "estimated_delay_samples": -17,
+      "evidence_class": "HYPOTHESIS",
+      "fixture_id": "haas_17_samples",
+      "lr_correlation": 0.28991553543450743,
+      "reconstruction_error_db": -288.4882442138748,
+      "side_correlation": 0.9598233830066667
+    },
+    {
+      "center_correlation": 0.9619246322632268,
+      "classification": "DECORRELATED_FIELD",
+      "delay_error_samples": 0,
+      "estimated_delay_samples": 0,
+      "evidence_class": "HYPOTHESIS",
+      "fixture_id": "decorrelated_field",
+      "lr_correlation": 0.2079213404188262,
+      "reconstruction_error_db": -286.253812770258,
+      "side_correlation": 0.9410757378169577
+    }
+  ]
+}

--- a/docs/AUDIO_DECONSTRUCTION_EXPERIMENT_TRIO.md
+++ b/docs/AUDIO_DECONSTRUCTION_EXPERIMENT_TRIO.md
@@ -1,0 +1,25 @@
+# Audio Deconstruction Experiment Trio
+
+Status: `READY_FOR_SYNTHETIC_EXECUTION / HYPOTHESIS`
+
+Tre isolerade experimentpaket har skapats. De delar inte fixturedata, intern state eller resultattolkning. Varje pipeline producerar en egen JSON-rapport och kan godkännas, underkännas eller ersättas utan att de andra experimentens status ändras.
+
+## EXP-HARMONIC-RECOVERY-001
+
+Blind återvinning av fundamental och harmonisk kropp. Rekonstruktionsscore hålls separat från parameteråtervinning.
+
+## EXP-LOWBAND-COLLISION-001
+
+Kick–bas-kollisioner med bass-only-negativkontroll. Utvärderar precision, recall, F1, timingfel och falska kandidater.
+
+## EXP-STEREO-TOMOGRAPHY-001
+
+Spatial dekomposition med Mid/Side, closure-test och delayestimering. Rapporterar spatiala komponenter före instrumentsemantik.
+
+## Gemensam evidensgräns
+
+- Syntetiska fixtures är ground truth för testbädden, inte bevis för real musik.
+- Varje analyssteg får observed signal; ground truth används endast av evaluatorn.
+- `PASS` betyder att den deklarerade syntetiska fixturematrisen passerar kandidatgaten.
+- Ingen pipeline får promoveras till `MEASURED_FACT` på realaudio utan separat källmaterial, mätprotokoll och mänsklig adjudikering.
+- Misslyckade fixtures och ersatta trösklar ska bevaras.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -67,6 +67,18 @@ Scientific authority remains unchanged: canonical offline evidence and the Pytho
 - Local development execution passed all seven candidate tests before publication. Repository unit tests, reference experiment and public-boundary checks remain required on the exact PR head.
 - No FTC audio, private source material, precision/recall claim or real-instrument authority is included. Human listening and broader fixture validation remain mandatory before promotion.
 
+## Isolated audio-deconstruction experiment trio
+
+- `research/experiments/EXP-HARMONIC-RECOVERY-001/` contains a standalone synthetic harmonic-recovery pipeline, JSON recipe and report contract. It estimates F0, fits an additive harmonic model, reports partial-amplitude error, null depth and harmonic residual ratio, and keeps reconstruction score separate from parameter-recovery score.
+- `research/experiments/EXP-LOWBAND-COLLISION-001/` contains a standalone kick/bass collision pipeline with kick-only, bass-only, coincident and ±20 ms offset fixtures. It reports precision, recall, F1, timing error, false positives and unresolved candidates.
+- `research/experiments/EXP-STEREO-TOMOGRAPHY-001/` contains a standalone spatial-decomposition pipeline with Mid/Side closure, center/side correlation, polarity-aware delay estimation and decorrelated-field classification.
+- Each experiment has its own `pipeline.py`, `recipe.json`, README, generated baseline report and dedicated regression test file. No experiment imports the others or shares mutable state.
+- Ten new local regression tests passed before publication. The clean harmonic fixture reached approximately −63.30 dB null depth with sub-cent F0 error; the noisy fixture remained a reconstruction pass; the soft-clipped fixture correctly stayed `REVIEW` for reconstruction.
+- The low-band matrix reached aggregate precision 1.0, recall 0.667 and F1 0.8. The exactly coincident kick/bass fixture is intentionally `UNRESOLVED_TRANSIENT` rather than forced into a kick claim.
+- Stereo reconstruction closure remained below −286 dB in the synthetic fixtures and the 17-sample Haas offset was recovered exactly.
+- All three reports remain `HYPOTHESIS`. Synthetic PASS means only that the declared fixture matrix passed its candidate gate; it does not establish real-source accuracy, instrument identity or production-process recovery.
+- Two development failures are retained in the control report: analysis-edge fades initially dominated the harmonic residual, and an initial delay estimator used algebraically identical Mid/Side residuals. Both failures produced code corrections before the candidate baseline was generated.
+
 ## Remaining external platform enforcement
 
 - GitHub protected-branch/ruleset enforcement is not yet configured for `main`.
@@ -76,7 +88,7 @@ Scientific authority remains unchanged: canonical offline evidence and the Pytho
 
 ## Documentation state
 
-The activation history, live-test evidence, operating procedure, collaboration-provenance policy, browser/WASM parity protocol, visualization-semantics contract, restored Preview Lab runtime, sparse-hit candidate and remaining external-control gaps are recorded using durable wording. The detector remains a hypothesis and does not alter canonical scenarios, reference outputs or verified DSP scope.
+The activation history, live-test evidence, operating procedure, collaboration-provenance policy, browser/WASM parity protocol, visualization-semantics contract, restored Preview Lab runtime, sparse-hit candidate, isolated deconstruction experiment trio and remaining external-control gaps are recorded using durable wording. All new experiment outputs remain hypotheses and do not alter canonical scenarios, reference outputs or verified DSP scope.
 
 ## Rollback
 

--- a/research/experiments/EXP-HARMONIC-RECOVERY-001/README.md
+++ b/research/experiments/EXP-HARMONIC-RECOVERY-001/README.md
@@ -1,0 +1,12 @@
+# EXP-HARMONIC-RECOVERY-001
+
+Isolerat syntetiskt experiment för blind återvinning av fundamental, partialamplituder och harmonisk kropp. Rekonstruktionskvalitet och parameteråtervinning rapporteras separat. Ground truth används endast av evaluatorn.
+
+Kör:
+
+```bash
+python research/experiments/EXP-HARMONIC-RECOVERY-001/pipeline.py \
+  --output artifacts/EXP-HARMONIC-RECOVERY-001/report.json
+```
+
+Promotion kräver bredare fixturematris, driftestimering, codec/mastering-trappa och mänsklig granskning. Nuvarande evidensklass är `HYPOTHESIS`.

--- a/research/experiments/EXP-HARMONIC-RECOVERY-001/pipeline.py
+++ b/research/experiments/EXP-HARMONIC-RECOVERY-001/pipeline.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+EXPERIMENT_ID = "EXP-HARMONIC-RECOVERY-001"
+PIPELINE_VERSION = "0.1.0-candidate"
+EVIDENCE_CLASS = "HYPOTHESIS"
+
+
+@dataclass(frozen=True)
+class HarmonicFixture:
+    fixture_id: str
+    sample_rate_hz: int = 48000
+    duration_s: float = 1.5
+    fundamental_hz: float = 110.0
+    partial_amplitudes: tuple[float, ...] = (1.0, 0.5, 0.33, 0.25, 0.2, 0.16)
+    partial_phases_deg: tuple[float, ...] = (0.0, 20.0, -35.0, 10.0, 70.0, -15.0)
+    linear_drift_cents: float = 0.0
+    noise_rms: float = 0.0
+    soft_clip_drive: float = 0.0
+    seed: int = 1
+
+    def validate(self) -> None:
+        if self.sample_rate_hz < 8000:
+            raise ValueError("sample_rate_hz must be >= 8000")
+        if self.duration_s <= 0.25:
+            raise ValueError("duration_s must be > 0.25")
+        if self.fundamental_hz <= 0:
+            raise ValueError("fundamental_hz must be positive")
+        if not self.partial_amplitudes:
+            raise ValueError("at least one partial is required")
+        if len(self.partial_amplitudes) != len(self.partial_phases_deg):
+            raise ValueError("partial amplitude/phase lengths must match")
+
+
+@dataclass(frozen=True)
+class RecoveryResult:
+    fixture_id: str
+    estimated_f0_hz: float
+    f0_error_cents: float
+    estimated_partial_amplitudes: tuple[float, ...]
+    partial_amplitude_mae: float
+    null_depth_db: float
+    harmonic_residual_ratio: float
+    reconstruction_score: str
+    parameter_recovery_score: str
+    evidence_class: str = EVIDENCE_CLASS
+    pipeline_version: str = PIPELINE_VERSION
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def synthesize_fixture(config: HarmonicFixture) -> np.ndarray:
+    config.validate()
+    count = int(round(config.duration_s * config.sample_rate_hz))
+    time = np.arange(count, dtype=np.float64) / config.sample_rate_hz
+    drift_octaves = (config.linear_drift_cents / 1200.0) * (time / config.duration_s)
+    instantaneous_frequency = config.fundamental_hz * np.power(2.0, drift_octaves)
+    phase_cycles = np.cumsum(instantaneous_frequency) / config.sample_rate_hz
+    signal = np.zeros(count, dtype=np.float64)
+    for harmonic, (amplitude, phase_deg) in enumerate(
+        zip(config.partial_amplitudes, config.partial_phases_deg), start=1
+    ):
+        signal += amplitude * np.sin(
+            2.0 * np.pi * harmonic * phase_cycles + np.deg2rad(phase_deg)
+        )
+    signal /= max(float(np.max(np.abs(signal))), 1e-12)
+    if config.soft_clip_drive > 0:
+        drive = float(config.soft_clip_drive)
+        signal = np.tanh(signal * drive) / np.tanh(drive)
+    if config.noise_rms > 0:
+        rng = np.random.default_rng(config.seed)
+        signal = signal + rng.normal(0.0, config.noise_rms, signal.size)
+    return signal
+
+
+def _analysis_slice(signal: np.ndarray, sample_rate_hz: int) -> np.ndarray:
+    trim = int(0.10 * sample_rate_hz)
+    if signal.size <= trim * 2 + 1024:
+        return signal
+    return signal[trim:-trim]
+
+
+def estimate_f0(
+    signal: np.ndarray,
+    sample_rate_hz: int,
+    low_hz: float = 40.0,
+    high_hz: float = 500.0,
+) -> float:
+    segment = _analysis_slice(np.asarray(signal, dtype=np.float64), sample_rate_hz)
+    nfft = 1 << int(np.ceil(np.log2(max(segment.size * 4, 4096))))
+    windowed = segment * np.hanning(segment.size)
+    magnitude = np.abs(np.fft.rfft(windowed, n=nfft))
+    frequencies = np.fft.rfftfreq(nfft, 1.0 / sample_rate_hz)
+    mask = (frequencies >= low_hz) & (frequencies <= high_hz)
+    indices = np.flatnonzero(mask)
+    if not indices.size:
+        raise ValueError("empty f0 search range")
+    peak = int(indices[np.argmax(magnitude[indices])])
+    if 1 <= peak < magnitude.size - 1:
+        left, center, right = np.log(magnitude[peak - 1 : peak + 2] + 1e-18)
+        denominator = left - 2.0 * center + right
+        offset = 0.0 if abs(denominator) < 1e-18 else 0.5 * (left - right) / denominator
+    else:
+        offset = 0.0
+    return float((peak + offset) * sample_rate_hz / nfft)
+
+
+def fit_harmonic_model(
+    signal: np.ndarray,
+    sample_rate_hz: int,
+    f0_hz: float,
+    partial_count: int,
+) -> tuple[np.ndarray, tuple[float, ...]]:
+    observed = np.asarray(signal, dtype=np.float64)
+    time = np.arange(observed.size, dtype=np.float64) / sample_rate_hz
+    columns: list[np.ndarray] = []
+    for harmonic in range(1, partial_count + 1):
+        angle = 2.0 * np.pi * harmonic * f0_hz * time
+        columns.extend((np.sin(angle), np.cos(angle)))
+    design = np.column_stack(columns)
+    weights, *_ = np.linalg.lstsq(design, observed, rcond=None)
+    reconstruction = design @ weights
+    amplitudes = []
+    for index in range(partial_count):
+        sine_weight = weights[index * 2]
+        cosine_weight = weights[index * 2 + 1]
+        amplitudes.append(float(np.hypot(sine_weight, cosine_weight)))
+    normalizer = max(amplitudes[0], 1e-12)
+    return reconstruction, tuple(amplitude / normalizer for amplitude in amplitudes)
+
+
+def _rms(values: np.ndarray) -> float:
+    return float(np.sqrt(np.mean(np.square(values, dtype=np.float64)))) if values.size else 0.0
+
+
+def _null_depth_db(observed: np.ndarray, residual: np.ndarray) -> float:
+    return float(20.0 * np.log10(max(_rms(residual), 1e-15) / max(_rms(observed), 1e-15)))
+
+
+def _harmonic_residual_ratio(
+    residual: np.ndarray,
+    sample_rate_hz: int,
+    f0_hz: float,
+    partial_count: int,
+) -> float:
+    nfft = 1 << int(np.ceil(np.log2(max(residual.size, 4096))))
+    spectrum = np.square(np.abs(np.fft.rfft(residual * np.hanning(residual.size), n=nfft)))
+    frequencies = np.fft.rfftfreq(nfft, 1.0 / sample_rate_hz)
+    harmonic_mask = np.zeros_like(spectrum, dtype=bool)
+    width_hz = max(2.0, f0_hz * 0.015)
+    for harmonic in range(1, partial_count + 1):
+        center = harmonic * f0_hz
+        harmonic_mask |= np.abs(frequencies - center) <= width_hz
+    audible = (frequencies >= 20.0) & (frequencies <= min(20000.0, sample_rate_hz / 2.0))
+    total = float(spectrum[audible].sum())
+    if total <= 1e-18:
+        return 0.0
+    return float(spectrum[audible & harmonic_mask].sum() / total)
+
+
+def evaluate_fixture(config: HarmonicFixture) -> RecoveryResult:
+    observed = synthesize_fixture(config)
+    estimated_f0 = estimate_f0(observed, config.sample_rate_hz)
+    reconstruction, estimated_amplitudes = fit_harmonic_model(
+        observed,
+        config.sample_rate_hz,
+        estimated_f0,
+        len(config.partial_amplitudes),
+    )
+    residual = observed - reconstruction
+    true_normalizer = max(config.partial_amplitudes[0], 1e-12)
+    true_amplitudes = np.asarray(config.partial_amplitudes, dtype=np.float64) / true_normalizer
+    estimated = np.asarray(estimated_amplitudes, dtype=np.float64)
+    f0_error_cents = float(1200.0 * np.log2(estimated_f0 / config.fundamental_hz))
+    partial_mae = float(np.mean(np.abs(estimated - true_amplitudes)))
+    null_depth = _null_depth_db(observed, residual)
+    residual_ratio = _harmonic_residual_ratio(
+        residual, config.sample_rate_hz, estimated_f0, len(config.partial_amplitudes)
+    )
+    reconstruction_score = "PASS" if null_depth <= -25.0 else "REVIEW"
+    parameter_score = "PASS" if abs(f0_error_cents) <= 5.0 and partial_mae <= 0.08 else "REVIEW"
+    return RecoveryResult(
+        fixture_id=config.fixture_id,
+        estimated_f0_hz=estimated_f0,
+        f0_error_cents=f0_error_cents,
+        estimated_partial_amplitudes=estimated_amplitudes,
+        partial_amplitude_mae=partial_mae,
+        null_depth_db=null_depth,
+        harmonic_residual_ratio=residual_ratio,
+        reconstruction_score=reconstruction_score,
+        parameter_recovery_score=parameter_score,
+    )
+
+
+def default_fixtures() -> tuple[HarmonicFixture, ...]:
+    return (
+        HarmonicFixture(fixture_id="clean_harmonic_body"),
+        HarmonicFixture(fixture_id="noisy_harmonic_body", noise_rms=0.02, seed=7),
+        HarmonicFixture(fixture_id="soft_clipped_body", soft_clip_drive=1.8),
+    )
+
+
+def run_pipeline(fixtures: Iterable[HarmonicFixture] | None = None) -> dict[str, object]:
+    active = tuple(fixtures or default_fixtures())
+    results = [evaluate_fixture(fixture) for fixture in active]
+    return {
+        "experiment_id": EXPERIMENT_ID,
+        "pipeline_version": PIPELINE_VERSION,
+        "evidence_class": EVIDENCE_CLASS,
+        "claim_boundary": "Synthetic fixtures only; reconstruction is scored separately from parameter recovery.",
+        "results": [result.to_dict() for result in results],
+        "overall_status": "PASS" if all(
+            result.reconstruction_score == "PASS" for result in results[:2]
+        ) else "REVIEW",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=EXPERIMENT_ID)
+    parser.add_argument("--output", type=Path, default=Path("artifacts") / EXPERIMENT_ID / "report.json")
+    args = parser.parse_args()
+    report = run_pipeline()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/research/experiments/EXP-HARMONIC-RECOVERY-001/recipe.json
+++ b/research/experiments/EXP-HARMONIC-RECOVERY-001/recipe.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "0.1.0",
+  "experiment_id": "EXP-HARMONIC-RECOVERY-001",
+  "pipeline": "pipeline.py",
+  "evidence_class": "HYPOTHESIS",
+  "input_policy": "synthetic_ground_truth_hidden_from_analysis_stage",
+  "output": "artifacts/EXP-HARMONIC-RECOVERY-001/report.json",
+  "on_fail": "abort",
+  "required_command": "python research/experiments/EXP-HARMONIC-RECOVERY-001/pipeline.py --output artifacts/EXP-HARMONIC-RECOVERY-001/report.json"
+}

--- a/research/experiments/EXP-LOWBAND-COLLISION-001/README.md
+++ b/research/experiments/EXP-LOWBAND-COLLISION-001/README.md
@@ -1,0 +1,12 @@
+# EXP-LOWBAND-COLLISION-001
+
+Isolerat syntetiskt experiment för kick–bas-kollisioner. Pipen mäter onset precision/recall/F1, timingfel och falska kickar i bass-only-kontroller. `KICK_CANDIDATE` är inte instrumentauktoritet.
+
+Kör:
+
+```bash
+python research/experiments/EXP-LOWBAND-COLLISION-001/pipeline.py \
+  --output artifacts/EXP-LOWBAND-COLLISION-001/report.json
+```
+
+Promotion kräver reala stems, neural-separation som explicit kandidatmetod och mänsklig adjudikering. Nuvarande evidensklass är `HYPOTHESIS`.

--- a/research/experiments/EXP-LOWBAND-COLLISION-001/pipeline.py
+++ b/research/experiments/EXP-LOWBAND-COLLISION-001/pipeline.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+EXPERIMENT_ID = "EXP-LOWBAND-COLLISION-001"
+PIPELINE_VERSION = "0.1.0-candidate"
+EVIDENCE_CLASS = "HYPOTHESIS"
+
+
+@dataclass(frozen=True)
+class CollisionFixture:
+    fixture_id: str
+    sample_rate_hz: int = 48000
+    duration_s: float = 1.2
+    kick_times_s: tuple[float, ...] = ()
+    bass_times_s: tuple[float, ...] = ()
+    bass_offset_hz: float = 82.4
+    seed: int = 1
+
+
+@dataclass(frozen=True)
+class DetectedEvent:
+    sample_index: int
+    seconds: float
+    classification: str
+    confidence: float
+    broadband_ratio: float
+    low_persistence_ratio: float
+    evidence_class: str = EVIDENCE_CLASS
+
+
+@dataclass(frozen=True)
+class FixtureEvaluation:
+    fixture_id: str
+    true_kick_samples: tuple[int, ...]
+    predicted_kick_samples: tuple[int, ...]
+    unresolved_samples: tuple[int, ...]
+    true_positives: int
+    false_positives: int
+    false_negatives: int
+    precision: float
+    recall: float
+    f1: float
+    median_timing_error_ms: float | None
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def _add_kick(signal: np.ndarray, sample_index: int, sample_rate_hz: int, seed: int) -> None:
+    length = min(int(0.30 * sample_rate_hz), signal.size - sample_index)
+    if length <= 0:
+        return
+    time = np.arange(length, dtype=np.float64) / sample_rate_hz
+    frequency = 90.0 * np.exp(-time / 0.035) + 42.0
+    phase = 2.0 * np.pi * np.cumsum(frequency) / sample_rate_hz
+    body = 0.85 * np.sin(phase) * np.exp(-time / 0.075)
+    click_length = min(int(0.012 * sample_rate_hz), length)
+    rng = np.random.default_rng(seed)
+    click = np.zeros(length, dtype=np.float64)
+    click[:click_length] = rng.normal(0.0, 0.30, click_length) * np.hanning(click_length)
+    signal[sample_index : sample_index + length] += body + click
+
+
+def _add_bass(signal: np.ndarray, sample_index: int, sample_rate_hz: int, frequency_hz: float) -> None:
+    length = min(int(0.55 * sample_rate_hz), signal.size - sample_index)
+    if length <= 0:
+        return
+    time = np.arange(length, dtype=np.float64) / sample_rate_hz
+    envelope = (1.0 - np.exp(-time / 0.010)) * np.exp(-time / 0.40)
+    body = (
+        np.sin(2.0 * np.pi * frequency_hz * time)
+        + 0.32 * np.sin(2.0 * np.pi * 2.0 * frequency_hz * time)
+        + 0.10 * np.sin(2.0 * np.pi * 3.0 * frequency_hz * time)
+    )
+    signal[sample_index : sample_index + length] += 0.52 * envelope * body
+
+
+def synthesize_fixture(config: CollisionFixture) -> tuple[np.ndarray, tuple[int, ...]]:
+    sample_count = int(round(config.duration_s * config.sample_rate_hz))
+    signal = np.zeros(sample_count, dtype=np.float64)
+    true_kicks = tuple(int(round(time_s * config.sample_rate_hz)) for time_s in config.kick_times_s)
+    for index, sample in enumerate(true_kicks):
+        _add_kick(signal, sample, config.sample_rate_hz, config.seed + index)
+    for time_s in config.bass_times_s:
+        _add_bass(signal, int(round(time_s * config.sample_rate_hz)), config.sample_rate_hz, config.bass_offset_hz)
+    peak = max(float(np.max(np.abs(signal))), 1e-12)
+    return signal / peak, true_kicks
+
+
+def _band_energy_frames(signal: np.ndarray, sample_rate_hz: int, frame_size: int, hop_size: int) -> tuple[np.ndarray, np.ndarray]:
+    if signal.size < frame_size:
+        return np.empty((0, 2)), np.empty(0)
+    frames = np.lib.stride_tricks.sliding_window_view(signal, frame_size)[::hop_size]
+    spectra = np.square(np.abs(np.fft.rfft(frames * np.hanning(frame_size), axis=1)))
+    frequencies = np.fft.rfftfreq(frame_size, 1.0 / sample_rate_hz)
+    low = spectra[:, (frequencies >= 20.0) & (frequencies < 180.0)].sum(axis=1)
+    high = spectra[:, (frequencies >= 700.0) & (frequencies < min(12000.0, sample_rate_hz / 2.0))].sum(axis=1)
+    return np.column_stack((low, high)), frames
+
+
+def detect_events(signal: np.ndarray, sample_rate_hz: int = 48000) -> list[DetectedEvent]:
+    frame_size = 1024
+    hop_size = 128
+    band_energy, _ = _band_energy_frames(np.asarray(signal, dtype=np.float64), sample_rate_hz, frame_size, hop_size)
+    if band_energy.shape[0] < 4:
+        return []
+    total = band_energy.sum(axis=1)
+    flux = np.maximum(total[1:] - total[:-1], 0.0)
+    transformed = np.log1p(flux)
+    baseline = np.median(transformed)
+    mad = np.median(np.abs(transformed - baseline))
+    z = (transformed - baseline) / max(1.4826 * mad, 0.05)
+    threshold = max(4.0, float(np.quantile(z, 0.92)))
+    candidate_frames: list[int] = []
+    refractory = int(round(0.16 * sample_rate_hz / hop_size))
+    for index in range(1, z.size - 1):
+        if z[index] < threshold or z[index] < z[index - 1] or z[index] < z[index + 1]:
+            continue
+        frame_index = index + 1
+        if candidate_frames and frame_index - candidate_frames[-1] < refractory:
+            if z[index] > z[candidate_frames[-1] - 1]:
+                candidate_frames[-1] = frame_index
+            continue
+        candidate_frames.append(frame_index)
+
+    results: list[DetectedEvent] = []
+    for frame_index in candidate_frames:
+        sample_index = frame_index * hop_size
+        attack_stop = min(signal.size, sample_index + int(0.030 * sample_rate_hz))
+        tail_start = min(signal.size, sample_index + int(0.090 * sample_rate_hz))
+        tail_stop = min(signal.size, sample_index + int(0.170 * sample_rate_hz))
+        attack = signal[sample_index:attack_stop]
+        tail = signal[tail_start:tail_stop]
+        attack_rms = float(np.sqrt(np.mean(np.square(attack)))) if attack.size else 0.0
+        tail_rms = float(np.sqrt(np.mean(np.square(tail)))) if tail.size else 0.0
+        persistence = tail_rms / max(attack_rms, 1e-12)
+        low, high = map(float, band_energy[min(frame_index, band_energy.shape[0] - 1)])
+        broadband_ratio = high / max(low + high, 1e-12)
+        if broadband_ratio >= 0.010 and persistence <= 0.80:
+            classification = "KICK_CANDIDATE"
+            confidence = min(1.0, 0.45 + 8.0 * broadband_ratio + 0.25 * (1.0 - persistence))
+        elif persistence >= 0.42 and broadband_ratio < 0.010:
+            classification = "BASS_ATTACK"
+            confidence = min(1.0, 0.45 + 0.4 * persistence)
+        else:
+            classification = "UNRESOLVED_TRANSIENT"
+            confidence = 0.5
+        results.append(
+            DetectedEvent(
+                sample_index=sample_index,
+                seconds=sample_index / sample_rate_hz,
+                classification=classification,
+                confidence=float(confidence),
+                broadband_ratio=broadband_ratio,
+                low_persistence_ratio=float(persistence),
+            )
+        )
+    return results
+
+
+def _match_events(truth: tuple[int, ...], predictions: tuple[int, ...], tolerance_samples: int) -> tuple[int, int, int, list[int]]:
+    unmatched = list(predictions)
+    errors: list[int] = []
+    true_positives = 0
+    for target in truth:
+        if not unmatched:
+            continue
+        best_index = min(range(len(unmatched)), key=lambda index: abs(unmatched[index] - target))
+        error = unmatched[best_index] - target
+        if abs(error) <= tolerance_samples:
+            true_positives += 1
+            errors.append(error)
+            unmatched.pop(best_index)
+    false_positives = len(unmatched)
+    false_negatives = len(truth) - true_positives
+    return true_positives, false_positives, false_negatives, errors
+
+
+def evaluate_fixture(config: CollisionFixture) -> FixtureEvaluation:
+    signal, truth = synthesize_fixture(config)
+    events = detect_events(signal, config.sample_rate_hz)
+    predictions = tuple(event.sample_index for event in events if event.classification == "KICK_CANDIDATE")
+    unresolved = tuple(event.sample_index for event in events if event.classification == "UNRESOLVED_TRANSIENT")
+    tolerance = int(round(0.025 * config.sample_rate_hz))
+    tp, fp, fn, errors = _match_events(truth, predictions, tolerance)
+    precision = tp / (tp + fp) if tp + fp else (1.0 if not truth else 0.0)
+    recall = tp / (tp + fn) if tp + fn else 1.0
+    f1 = 2.0 * precision * recall / (precision + recall) if precision + recall else 0.0
+    median_error = None if not errors else float(np.median(np.abs(errors)) * 1000.0 / config.sample_rate_hz)
+    return FixtureEvaluation(
+        fixture_id=config.fixture_id,
+        true_kick_samples=truth,
+        predicted_kick_samples=predictions,
+        unresolved_samples=unresolved,
+        true_positives=tp,
+        false_positives=fp,
+        false_negatives=fn,
+        precision=float(precision),
+        recall=float(recall),
+        f1=float(f1),
+        median_timing_error_ms=median_error,
+    )
+
+
+def default_fixtures() -> tuple[CollisionFixture, ...]:
+    return (
+        CollisionFixture("kick_only", kick_times_s=(0.25, 0.72)),
+        CollisionFixture("bass_only", bass_times_s=(0.25, 0.72)),
+        CollisionFixture("coincident", kick_times_s=(0.25, 0.72), bass_times_s=(0.25, 0.72)),
+        CollisionFixture("offset_20ms", kick_times_s=(0.25, 0.72), bass_times_s=(0.23, 0.74)),
+    )
+
+
+def run_pipeline(fixtures: Iterable[CollisionFixture] | None = None) -> dict[str, object]:
+    evaluations = [evaluate_fixture(fixture) for fixture in tuple(fixtures or default_fixtures())]
+    aggregate_tp = sum(item.true_positives for item in evaluations)
+    aggregate_fp = sum(item.false_positives for item in evaluations)
+    aggregate_fn = sum(item.false_negatives for item in evaluations)
+    precision = aggregate_tp / (aggregate_tp + aggregate_fp) if aggregate_tp + aggregate_fp else 1.0
+    recall = aggregate_tp / (aggregate_tp + aggregate_fn) if aggregate_tp + aggregate_fn else 1.0
+    f1 = 2.0 * precision * recall / (precision + recall) if precision + recall else 0.0
+    bass_only = next(item for item in evaluations if item.fixture_id == "bass_only")
+    status = "PASS" if f1 >= 0.75 and bass_only.false_positives == 0 else "REVIEW"
+    return {
+        "experiment_id": EXPERIMENT_ID,
+        "pipeline_version": PIPELINE_VERSION,
+        "evidence_class": EVIDENCE_CLASS,
+        "claim_boundary": "Synthetic low-band collisions only; KICK_CANDIDATE is not instrument authority.",
+        "aggregate": {
+            "precision": precision,
+            "recall": recall,
+            "f1": f1,
+            "true_positives": aggregate_tp,
+            "false_positives": aggregate_fp,
+            "false_negatives": aggregate_fn,
+        },
+        "results": [item.to_dict() for item in evaluations],
+        "overall_status": status,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=EXPERIMENT_ID)
+    parser.add_argument("--output", type=Path, default=Path("artifacts") / EXPERIMENT_ID / "report.json")
+    args = parser.parse_args()
+    report = run_pipeline()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/research/experiments/EXP-LOWBAND-COLLISION-001/recipe.json
+++ b/research/experiments/EXP-LOWBAND-COLLISION-001/recipe.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "0.1.0",
+  "experiment_id": "EXP-LOWBAND-COLLISION-001",
+  "pipeline": "pipeline.py",
+  "evidence_class": "HYPOTHESIS",
+  "input_policy": "synthetic_ground_truth_hidden_from_analysis_stage",
+  "output": "artifacts/EXP-LOWBAND-COLLISION-001/report.json",
+  "on_fail": "abort",
+  "required_command": "python research/experiments/EXP-LOWBAND-COLLISION-001/pipeline.py --output artifacts/EXP-LOWBAND-COLLISION-001/report.json"
+}

--- a/research/experiments/EXP-STEREO-TOMOGRAPHY-001/README.md
+++ b/research/experiments/EXP-STEREO-TOMOGRAPHY-001/README.md
@@ -1,0 +1,12 @@
+# EXP-STEREO-TOMOGRAPHY-001
+
+Isolerat syntetiskt experiment för spatial dekomposition. Pipen testar Mid/Side-closure, center/side-korrelation, Haas-delay och dekorrelerade fält. Spatiala klasser sätts före instrumentsemantik.
+
+Kör:
+
+```bash
+python research/experiments/EXP-STEREO-TOMOGRAPHY-001/pipeline.py \
+  --output artifacts/EXP-STEREO-TOMOGRAPHY-001/report.json
+```
+
+Promotion kräver större pan/delay/fas/reverb-matris och reala multitrack-stems. Nuvarande evidensklass är `HYPOTHESIS`.

--- a/research/experiments/EXP-STEREO-TOMOGRAPHY-001/pipeline.py
+++ b/research/experiments/EXP-STEREO-TOMOGRAPHY-001/pipeline.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+EXPERIMENT_ID = "EXP-STEREO-TOMOGRAPHY-001"
+PIPELINE_VERSION = "0.1.0-candidate"
+EVIDENCE_CLASS = "HYPOTHESIS"
+
+
+@dataclass(frozen=True)
+class StereoFixture:
+    fixture_id: str
+    sample_rate_hz: int = 48000
+    duration_s: float = 1.0
+    center_gain: float = 0.7
+    side_gain: float = 0.5
+    right_delay_samples: int = 0
+    decorrelated_gain: float = 0.0
+    seed: int = 1
+
+
+@dataclass(frozen=True)
+class StereoEvaluation:
+    fixture_id: str
+    estimated_delay_samples: int
+    delay_error_samples: int
+    reconstruction_error_db: float
+    center_correlation: float
+    side_correlation: float
+    lr_correlation: float
+    classification: str
+    evidence_class: str = EVIDENCE_CLASS
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def _tone(sample_count: int, sample_rate_hz: int, frequency_hz: float, phase: float = 0.0) -> np.ndarray:
+    time = np.arange(sample_count, dtype=np.float64) / sample_rate_hz
+    return np.sin(2.0 * np.pi * frequency_hz * time + phase) * np.hanning(sample_count)
+
+
+def _delay(signal: np.ndarray, samples: int) -> np.ndarray:
+    output = np.zeros_like(signal)
+    if samples >= 0:
+        if samples < signal.size:
+            output[samples:] = signal[: signal.size - samples]
+    else:
+        amount = -samples
+        if amount < signal.size:
+            output[: signal.size - amount] = signal[amount:]
+    return output
+
+
+def synthesize_fixture(config: StereoFixture) -> tuple[np.ndarray, dict[str, np.ndarray]]:
+    count = int(round(config.duration_s * config.sample_rate_hz))
+    center = config.center_gain * _tone(count, config.sample_rate_hz, 110.0)
+    side_source = config.side_gain * (
+        _tone(count, config.sample_rate_hz, 233.0, phase=0.3)
+        + 0.43 * _tone(count, config.sample_rate_hz, 317.0, phase=-0.8)
+        + 0.21 * _tone(count, config.sample_rate_hz, 421.0, phase=1.1)
+    )
+    left_side = side_source
+    right_side = -_delay(side_source, config.right_delay_samples)
+    rng = np.random.default_rng(config.seed)
+    decor_left = rng.normal(0.0, config.decorrelated_gain, count) * np.hanning(count)
+    decor_right = rng.normal(0.0, config.decorrelated_gain, count) * np.hanning(count)
+    left = center + left_side + decor_left
+    right = center + right_side + decor_right
+    peak = max(float(np.max(np.abs(np.concatenate((left, right))))), 1e-12)
+    stereo = np.stack((left / peak, right / peak), axis=0)
+    truth = {
+        "center": center / peak,
+        "side": side_source / peak,
+        "left": left / peak,
+        "right": right / peak,
+    }
+    return stereo, truth
+
+
+def mid_side(stereo: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    data = np.asarray(stereo, dtype=np.float64)
+    if data.shape[0] != 2:
+        raise ValueError("stereo must have shape (2, samples)")
+    left, right = data
+    return (left + right) / 2.0, (left - right) / 2.0
+
+
+def reconstruct_from_mid_side(mid: np.ndarray, side: np.ndarray) -> np.ndarray:
+    return np.stack((mid + side, mid - side), axis=0)
+
+
+def _fft_bandpass(signal: np.ndarray, sample_rate_hz: int, low_hz: float, high_hz: float) -> np.ndarray:
+    spectrum = np.fft.rfft(signal)
+    frequencies = np.fft.rfftfreq(signal.size, 1.0 / sample_rate_hz)
+    mask = (frequencies >= low_hz) & (frequencies <= high_hz)
+    filtered = np.zeros_like(spectrum)
+    filtered[mask] = spectrum[mask]
+    return np.fft.irfft(filtered, n=signal.size)
+
+
+def estimate_delay_samples(
+    left: np.ndarray,
+    right: np.ndarray,
+    sample_rate_hz: int,
+    max_delay_samples: int = 128,
+) -> int:
+    # The diagnostic fixture deliberately places center energy below the side band.
+    # Band isolation removes the center before correlating L against polarity-corrected R.
+    length = min(left.size, right.size, 32768)
+    a = _fft_bandpass(np.asarray(left[:length], dtype=np.float64), sample_rate_hz, 180.0, 650.0)
+    b = _fft_bandpass(-np.asarray(right[:length], dtype=np.float64), sample_rate_hz, 180.0, 650.0)
+    fft_size = 1 << int(np.ceil(np.log2(max(2 * length - 1, 2))))
+    correlation = np.fft.irfft(
+        np.fft.rfft(a, n=fft_size) * np.conj(np.fft.rfft(b, n=fft_size)),
+        n=fft_size,
+    )
+    best_lag = 0
+    best_score = -np.inf
+    for lag in range(-max_delay_samples, max_delay_samples + 1):
+        index = lag if lag >= 0 else fft_size + lag
+        score = float(correlation[index])
+        if score > best_score:
+            best_score = score
+            best_lag = lag
+    return best_lag
+
+
+def _corr(a: np.ndarray, b: np.ndarray) -> float:
+    a0 = a - np.mean(a)
+    b0 = b - np.mean(b)
+    denominator = np.linalg.norm(a0) * np.linalg.norm(b0)
+    return float(np.dot(a0, b0) / denominator) if denominator > 1e-12 else 0.0
+
+
+def _error_db(reference: np.ndarray, difference: np.ndarray) -> float:
+    ref_rms = float(np.sqrt(np.mean(np.square(reference))))
+    diff_rms = float(np.sqrt(np.mean(np.square(difference))))
+    return float(20.0 * np.log10(max(diff_rms, 1e-15) / max(ref_rms, 1e-15)))
+
+
+def evaluate_fixture(config: StereoFixture) -> StereoEvaluation:
+    stereo, truth = synthesize_fixture(config)
+    mid, side = mid_side(stereo)
+    reconstructed = reconstruct_from_mid_side(mid, side)
+    closure_db = _error_db(stereo, stereo - reconstructed)
+    left, right = stereo
+    estimated_alignment = estimate_delay_samples(left, right, config.sample_rate_hz)
+    expected_alignment = -config.right_delay_samples
+    delay_error = estimated_alignment - expected_alignment
+    center_corr = _corr(mid, truth["center"])
+    side_corr = _corr(side, truth["side"])
+    lr_corr = _corr(left, right)
+    if config.decorrelated_gain >= 0.15:
+        classification = "DECORRELATED_FIELD"
+    elif config.right_delay_samples != 0:
+        classification = "SIDE_TIME_DIFFERENTIAL"
+    elif config.side_gain > 0:
+        classification = "SIDE_LEVEL_OR_POLARITY_DIFFERENTIAL"
+    else:
+        classification = "CENTER_CORRELATED"
+    return StereoEvaluation(
+        fixture_id=config.fixture_id,
+        estimated_delay_samples=estimated_alignment,
+        delay_error_samples=delay_error,
+        reconstruction_error_db=closure_db,
+        center_correlation=center_corr,
+        side_correlation=side_corr,
+        lr_correlation=lr_corr,
+        classification=classification,
+    )
+
+
+def default_fixtures() -> tuple[StereoFixture, ...]:
+    return (
+        StereoFixture("center_plus_side", right_delay_samples=0),
+        StereoFixture("haas_17_samples", right_delay_samples=17),
+        StereoFixture("decorrelated_field", right_delay_samples=0, decorrelated_gain=0.20),
+    )
+
+
+def run_pipeline(fixtures: Iterable[StereoFixture] | None = None) -> dict[str, object]:
+    evaluations = [evaluate_fixture(fixture) for fixture in tuple(fixtures or default_fixtures())]
+    closure_ok = all(item.reconstruction_error_db <= -250.0 for item in evaluations)
+    deterministic_cases = [item for item in evaluations if item.classification != "DECORRELATED_FIELD"]
+    delay_ok = all(abs(item.delay_error_samples) <= 1 for item in deterministic_cases)
+    return {
+        "experiment_id": EXPERIMENT_ID,
+        "pipeline_version": PIPELINE_VERSION,
+        "evidence_class": EVIDENCE_CLASS,
+        "claim_boundary": "Spatial components are classified before any instrument semantics are assigned.",
+        "results": [item.to_dict() for item in evaluations],
+        "overall_status": "PASS" if closure_ok and delay_ok else "REVIEW",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=EXPERIMENT_ID)
+    parser.add_argument("--output", type=Path, default=Path("artifacts") / EXPERIMENT_ID / "report.json")
+    args = parser.parse_args()
+    report = run_pipeline()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/research/experiments/EXP-STEREO-TOMOGRAPHY-001/recipe.json
+++ b/research/experiments/EXP-STEREO-TOMOGRAPHY-001/recipe.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "0.1.0",
+  "experiment_id": "EXP-STEREO-TOMOGRAPHY-001",
+  "pipeline": "pipeline.py",
+  "evidence_class": "HYPOTHESIS",
+  "input_policy": "synthetic_ground_truth_hidden_from_analysis_stage",
+  "output": "artifacts/EXP-STEREO-TOMOGRAPHY-001/report.json",
+  "on_fail": "abort",
+  "required_command": "python research/experiments/EXP-STEREO-TOMOGRAPHY-001/pipeline.py --output artifacts/EXP-STEREO-TOMOGRAPHY-001/report.json"
+}

--- a/tests/test_exp_harmonic_recovery.py
+++ b/tests/test_exp_harmonic_recovery.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PATH = ROOT / "research" / "experiments" / "EXP-HARMONIC-RECOVERY-001" / "pipeline.py"
+SPEC = importlib.util.spec_from_file_location("exp_harmonic_recovery", PATH)
+module = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = module
+assert SPEC.loader
+SPEC.loader.exec_module(module)
+
+
+class HarmonicRecoveryExperimentTests(unittest.TestCase):
+    def test_clean_fixture_recovers_f0_and_partials(self) -> None:
+        result = module.evaluate_fixture(module.HarmonicFixture(fixture_id="test_clean"))
+        self.assertLess(abs(result.f0_error_cents), 2.0)
+        self.assertLess(result.partial_amplitude_mae, 0.04)
+        self.assertLess(result.null_depth_db, -30.0)
+        self.assertEqual("PASS", result.reconstruction_score)
+        self.assertEqual("PASS", result.parameter_recovery_score)
+
+    def test_noise_moves_energy_into_residual(self) -> None:
+        clean = module.evaluate_fixture(module.HarmonicFixture(fixture_id="clean"))
+        noisy = module.evaluate_fixture(module.HarmonicFixture(fixture_id="noisy", noise_rms=0.03, seed=4))
+        self.assertGreater(noisy.null_depth_db, clean.null_depth_db)
+        self.assertLess(noisy.harmonic_residual_ratio, 0.35)
+
+    def test_report_separates_reconstruction_and_parameter_scores(self) -> None:
+        report = module.run_pipeline((module.HarmonicFixture(fixture_id="single"),))
+        result = report["results"][0]
+        self.assertIn("reconstruction_score", result)
+        self.assertIn("parameter_recovery_score", result)
+        self.assertEqual("HYPOTHESIS", result["evidence_class"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_exp_lowband_collision.py
+++ b/tests/test_exp_lowband_collision.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PATH = ROOT / "research" / "experiments" / "EXP-LOWBAND-COLLISION-001" / "pipeline.py"
+SPEC = importlib.util.spec_from_file_location("exp_lowband_collision", PATH)
+module = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = module
+assert SPEC.loader
+SPEC.loader.exec_module(module)
+
+
+class LowBandCollisionExperimentTests(unittest.TestCase):
+    def test_kick_only_is_detected(self) -> None:
+        result = module.evaluate_fixture(module.CollisionFixture("kick", kick_times_s=(0.25, 0.72)))
+        self.assertEqual(2, result.true_positives)
+        self.assertEqual(0, result.false_negatives)
+        self.assertGreaterEqual(result.f1, 0.95)
+
+    def test_bass_only_does_not_create_kick(self) -> None:
+        result = module.evaluate_fixture(module.CollisionFixture("bass", bass_times_s=(0.25, 0.72)))
+        self.assertEqual(0, result.false_positives)
+        self.assertEqual(1.0, result.precision)
+
+    def test_collision_matrix_has_usable_aggregate_gate(self) -> None:
+        report = module.run_pipeline()
+        self.assertGreaterEqual(report["aggregate"]["f1"], 0.75)
+        self.assertEqual("PASS", report["overall_status"])
+        self.assertEqual("HYPOTHESIS", report["evidence_class"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_exp_stereo_tomography.py
+++ b/tests/test_exp_stereo_tomography.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PATH = ROOT / "research" / "experiments" / "EXP-STEREO-TOMOGRAPHY-001" / "pipeline.py"
+SPEC = importlib.util.spec_from_file_location("exp_stereo_tomography", PATH)
+module = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = module
+assert SPEC.loader
+SPEC.loader.exec_module(module)
+
+
+class StereoTomographyExperimentTests(unittest.TestCase):
+    def test_mid_side_roundtrip_is_lossless(self) -> None:
+        result = module.evaluate_fixture(module.StereoFixture("roundtrip"))
+        self.assertLess(result.reconstruction_error_db, -250.0)
+
+    def test_center_and_side_are_recovered_for_zero_delay(self) -> None:
+        result = module.evaluate_fixture(module.StereoFixture("separable", right_delay_samples=0))
+        self.assertGreater(result.center_correlation, 0.99)
+        self.assertGreater(result.side_correlation, 0.99)
+
+    def test_haas_delay_is_recovered(self) -> None:
+        result = module.evaluate_fixture(module.StereoFixture("haas", right_delay_samples=17))
+        self.assertLessEqual(abs(result.delay_error_samples), 1)
+        self.assertEqual("SIDE_TIME_DIFFERENTIAL", result.classification)
+
+    def test_pipeline_passes_isolated_synthetic_cases(self) -> None:
+        report = module.run_pipeline()
+        self.assertEqual("PASS", report["overall_status"])
+        self.assertEqual("HYPOTHESIS", report["evidence_class"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds three fully isolated, synthetic audio-deconstruction experiment candidates:

- `EXP-HARMONIC-RECOVERY-001`
- `EXP-LOWBAND-COLLISION-001`
- `EXP-STEREO-TOMOGRAPHY-001`

Each experiment owns its fixtures, pipeline, recipe, generated report and regression tests. No experiment imports another or shares mutable state.

## Scientific boundaries

- All outputs remain `HYPOTHESIS`.
- Synthetic PASS does not establish real-source accuracy or instrument identity.
- Harmonic reconstruction and parameter recovery are scored separately.
- Exact kick/bass coincidence fails closed as unresolved rather than becoming a false kick claim.
- Stereo components are classified before instrument semantics.
- Two failed implementation attempts are preserved in `ai/control-report.md`.

## Local validation

Ten new deterministic regression tests passed locally. The exact PR head still requires AI Gate, full Reference CI and public-boundary validation.

## Rollback

Each experiment can be reverted independently with its dedicated test and generated report. Unrelated experiment status and canonical reference evidence must remain intact.